### PR TITLE
hotfix: make banner aside use sticky position

### DIFF
--- a/src/components/privacy-banner/privacy-banner.jsx
+++ b/src/components/privacy-banner/privacy-banner.jsx
@@ -45,7 +45,7 @@ class PrivacyBanner extends React.Component {
         const privacyPolicyLink = chunks => <a href="/privacy_policy">{chunks}</a>;
         if (showBanner) {
             return (
-                <aside>
+                <aside className="privacy-aside">
                     <TitleBanner className="privacy-banner">
                         <div className="privacy-banner-container">
                             <img

--- a/src/components/privacy-banner/privacy-banner.scss
+++ b/src/components/privacy-banner/privacy-banner.scss
@@ -1,6 +1,9 @@
 @import "../../colors";
 @import "../../frameless";
 
+.privacy-aside {
+    position: sticky;
+}
 
 .privacy-banner {
     display: flex;


### PR DESCRIPTION
### Resolves:
- Fixes an issue where the privacy policy link did not work in Chrome.

### Changes:

- Adds `position: sticky` to the `aside` element containing the banner to prevent the margin of the main page `div` from blocking the link.
