### PR TITLE
Fix cookie expiring in session

### DIFF
--- a/src/components/privacy-banner/privacy-banner.jsx
+++ b/src/components/privacy-banner/privacy-banner.jsx
@@ -35,7 +35,7 @@ class PrivacyBanner extends React.Component {
 
     handleCloseBanner () {
         const opts = {
-            expires: new Date(new Date().setDate(new Date().getDate + 21)) // expires after 3 weeks
+            expires: new Date(new Date().setDate(new Date().getDate() + 21)) // expires after 3 weeks
         };
         this.setState({dismissedPrivacyBanner: true});
         jar.set('scratchpolicyseen', true, opts);


### PR DESCRIPTION
The scratchpolicyseen cookie is supposed to expire after 3 weeks, but due to a typo in the expiry time, it doesn't have a valid expiry, and falls back to expiring in Session. This has led to a lot of complaints by people about closing the popup but seeing it again later. This fixes that problem