### PR TITLE
build: enable GTM environments feature

### DIFF
--- a/src/template-config.js
+++ b/src/template-config.js
@@ -28,6 +28,23 @@ module.exports = {
     og_image_height: 860,
 
     // Analytics & Monitoring
+    // ----------------------
+
+    // GA4 Measurement ID
+    // Looks like 'G-XXXXXXXX'
+    ga4_id: process.env.GA4_ID || '',
+
+    // Universal Analytics Property ID
+    // Looks like 'UA-99999999-9'
     ga_tracker: process.env.GA_TRACKER || '',
-    gtm_id: process.env.GTM_ID || ''
+
+    // Google Tag Manager ID
+    // Looks like 'GTM-XXXXXXX'
+    gtm_id: process.env.GTM_ID || '',
+
+    // Google Tag Manager env & auth info for alterative GTM environments
+    // Looks like '&gtm_auth=0123456789abcdefghijklm&gtm_preview=env-00&gtm_cookies_win=x'
+    // Taken from the middle of: GTM -> Admin -> Environments -> (environment) -> Get Snippet
+    // Blank for production
+    gtm_env_auth: process.env.GTM_ENV_AUTH || ''
 };

--- a/src/template.ejs
+++ b/src/template.ejs
@@ -8,8 +8,9 @@
         <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
             new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
             j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-            'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-            })(window,document,'script','dataLayer','<%- htmlWebpackPlugin.options.gtm_id %>');</script>
+            'https://www.googletagmanager.com/gtm.js?id='+i+dl+'<%- htmlWebpackPlugin.options.gtm_env_auth %>';
+            f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','<%- htmlWebpackPlugin.options.gtm_id %>');
+        </script>
         <!-- End Google Tag Manager -->
         <% } %>
 
@@ -67,7 +68,7 @@
     <body>
         <% if (htmlWebpackPlugin.options.gtm_id) { %>
         <!-- Google Tag Manager (noscript) -->
-        <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=<%- htmlWebpackPlugin.options.gtm_id %>" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+        <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=<%- htmlWebpackPlugin.options.gtm_id %><%- htmlWebpackPlugin.options.gtm_env_auth %>" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
         <!-- End Google Tag Manager (noscript) -->
         <% } %>
         <noscript>


### PR DESCRIPTION
### Resolves:

Related to ENA-317

### Changes:

- Document all GA/GTM-related variables in `template-config.js`
- Add `gtm_env_auth` variable (from `GTM_ENV_AUTH` environment variable) to enable alternative GTM environments

This will let us test new versions of our production GTM configurations in staging without sending the data to our production data stream.

`GTM_ENV_AUTH` should be blank for production (the default environment). I've already set the correct value in the CI context for staging.

Because `GTM_ENV_AUTH` is blank for production, this should not affect production other than a harmless `+''` in the GTM script snippet.

### Test Coverage:

This can't be tested until it's deployed to staging since the GTM config depends on the hostname. Deploying to staging should wait until after the current release window.