### PR TITLE
REQ-56: update annual report link

### DIFF
--- a/src/views/about/about.jsx
+++ b/src/views/about/about.jsx
@@ -186,7 +186,7 @@ const About = injectIntl(({intl}) => (
                             ),
                             annualReportLink: (
                                 <a
-                                    href="/annual-report"
+                                    href="https://www.scratchfoundation.org/annualreport"
                                 >
                                     <FormattedMessage id="about.annualReportLinkText" />
                                 </a>


### PR DESCRIPTION
The annual report link on the about page pointed to a previous year's annual report, instead of the [current report ](https://www.scratchfoundation.org/annualreport) on the Scratch Foundation website. This PR changes the link URL to point to the correct page.

### Resolves:
- REQ-56

### Changes:
- Updates link URL