### PR TITLE
fix: add link to annual report in correct place

### DIFF
--- a/src/views/about/about.jsx
+++ b/src/views/about/about.jsx
@@ -208,7 +208,7 @@ const About = injectIntl(({intl}) => (
                             <a href="/educators"><FormattedMessage id="about.learnMoreEducators" /></a>
                         </li>
                         <li>
-                            <a href="/annual-report"><FormattedMessage id="about.learnMoreAnnualReport" /></a>
+                            <a href="https://www.scratchfoundation.org/annualreport"><FormattedMessage id="about.learnMoreAnnualReport" /></a>
                         </li>
                     </ul>
                 </li>


### PR DESCRIPTION
### Resolves:
issue in bug hunt

### Changes:
fixes link to incorrect annual report on about page
