### PR TITLE
Fix microbit hex

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -179,41 +179,21 @@ module.exports = {
         new CopyWebpackPlugin({
             patterns: [
                 {from: 'static'},
-                {from: 'intl', to: 'js'}
-            ]
-        }),
-        new CopyWebpackPlugin({
-            patterns: [
+                {from: 'intl', to: 'js'},
                 {
                     from: 'node_modules/scratch-gui/dist/static/blocks-media',
                     to: 'static/blocks-media'
-                }
-            ]
-        }),
-        new CopyWebpackPlugin({
-            patterns: [
+                },
                 {
                     from: 'node_modules/scratch-gui/dist/chunks',
                     to: 'static/chunks'
-                }
-            ]
-        }),
-        new CopyWebpackPlugin({
-            patterns: [
+                },
                 {
                     from: 'node_modules/scratch-gui/dist/extension-worker.js'
-                }
-            ]
-        }),
-        new CopyWebpackPlugin({
-            patterns: [
+                },
                 {
                     from: 'node_modules/scratch-gui/dist/extension-worker.js.map'
-                }
-            ]
-        }),
-        new CopyWebpackPlugin({
-            patterns: [
+                },
                 {
                     from: 'node_modules/scratch-gui/dist/static/assets',
                     to: 'static/assets'

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -197,6 +197,11 @@ module.exports = {
                 {
                     from: 'node_modules/scratch-gui/dist/static/assets',
                     to: 'static/assets'
+                },
+                {
+                    from: 'node_modules/scratch-gui/dist/*.hex',
+                    to: 'static',
+                    flatten: true
                 }
             ]
         }),


### PR DESCRIPTION
### Changes:

Fixes placement of the micro:bit HEX file for the new in-editor micro:bit update feature.

Also eliminates unnecessary instances of `CopyWebpackPlugin`. One instance of the plugin can handle many patterns, so there's no need to create separate instances like we were doing.

### Test Coverage:

Tested locally:

1. `npm start`
2. visit `http://localhost:8333/static/30d09ba32a17082ef820b57d52d60b7b.hex`
3. visit `http://localhost:8333/projects/editor/` and use the micro:bit update feature (requires a WebUSB-enabled browser)

I also compared the `/build` output before and after consolidating the `CopyWebpackPlugin` instances to make sure I wasn't missing some hidden reason to separate them.