### PR TITLE
Create redirect for annual report

### DIFF
--- a/src/routes.json
+++ b/src/routes.json
@@ -10,10 +10,7 @@
         "name": "annual-report",
         "pattern": "^/annual-report/?(\\?.*)?$",
         "routeAlias": "/annual-report/?$",
-        "view": "annual-report/2021/annual-report",
-        "title": "Annual Report 2021",
-        "intlName": "annual-report-2021",
-        "viewportWidth": "device-width"
+        "redirect": "https://www.scratchfoundation.org/annualreport"
     },
     {
         "name": "annual-report-2019",


### PR DESCRIPTION
Redirect scratch.mit.edu/annual-report to its new location on scratchfoundation.org. While the /2019, /2020, and /2021 subpages remain unaffected, /annual-report should always point to the most recent one