### PR TITLE
fix: pull in scratch-gui fix for ENA-343

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -101,7 +101,7 @@
         "regenerator-runtime": "0.13.9",
         "sass": "1.49.7",
         "sass-loader": "10.2.1",
-        "scratch-gui": "2.0.22",
+        "scratch-gui": "2.0.23-hotfix.2",
         "scratch-l10n": "3.15.20230627032203",
         "selenium-webdriver": "4.1.0",
         "slick-carousel": "1.6.0",
@@ -23539,9 +23539,9 @@
       }
     },
     "node_modules/scratch-gui": {
-      "version": "2.0.22",
-      "resolved": "https://registry.npmjs.org/scratch-gui/-/scratch-gui-2.0.22.tgz",
-      "integrity": "sha512-4xIypVGC3gSxwccBVFEcgGsZuxiB7OPC3oxQflEjnh1MCkZef5ZuKIwFP5F6Ap151S1N8if4tsWVEyBpnas2nw==",
+      "version": "2.0.23-hotfix.2",
+      "resolved": "https://registry.npmjs.org/scratch-gui/-/scratch-gui-2.0.23-hotfix.2.tgz",
+      "integrity": "sha512-LaKE3mRu7lqmCvo1mxrIHZltrKEcxh1Z3W7rDgwa5x1G6R0ClR4xo5nCULBeula97meXgI5UNGObedw0KwlfcQ==",
       "dev": true,
       "dependencies": {
         "@microbit/microbit-universal-hex": "0.2.2",

--- a/package.json
+++ b/package.json
@@ -136,7 +136,7 @@
     "regenerator-runtime": "0.13.9",
     "sass": "1.49.7",
     "sass-loader": "10.2.1",
-    "scratch-gui": "2.0.22",
+    "scratch-gui": "2.0.23-hotfix.2",
     "scratch-l10n": "3.15.20230627032203",
     "selenium-webdriver": "4.1.0",
     "slick-carousel": "1.6.0",


### PR DESCRIPTION
### Resolves:

Resolves ENA-343

### Changes:

Update `scratch-gui` dependency to a fixed version

### Test Coverage:

Tested locally on Chrome, Firefox, and Edge on Windows 11.
Manually tested by QA through BrowserStack.