### PR TITLE
fix: move the 'if Scratch Link is not running' advice into the Troubleshooting section

### DIFF
--- a/src/components/extension-landing/extension-troubleshooting.jsx
+++ b/src/components/extension-landing/extension-troubleshooting.jsx
@@ -4,6 +4,9 @@ const React = require('react');
 
 const ExtensionSection = require('./extension-section.jsx');
 
+const OS_ENUM = require('../../lib/os-enum.js');
+const {isDownloaded} = require('../install-scratch/install-util.js');
+
 // TODO: after the Scratch Conference 2022, migrate from the individual extension landing pages all the
 // troubleshooting steps which are common to all extensions.
 const ExtensionTroubleshooting = props => {
@@ -17,14 +20,24 @@ const ExtensionTroubleshooting = props => {
                 id="extensions.troubleshootingTitle"
                 values={sharedValues}
             /></h2>
-            <h3 className="faq-title"><FormattedMessage
-                id="extensions.browserCompatibilityTitle"
-                values={sharedValues}
-            /></h3>
-            <p><FormattedMessage
-                id="extensions.browserCompatibilityText"
-                values={sharedValues}
-            /></p>
+            {(isDownloaded(props.currentOS)) && (<React.Fragment>
+                <h3 className="faq-title"><FormattedMessage
+                    id="extensions.scratchLinkRunning"
+                    values={sharedValues}
+                /></h3>
+                <p><FormattedMessage
+                    id={`extensions.startScratchLink.${
+                        props.currentOS === OS_ENUM.WINDOWS ? 'Windows' : 'macOS'
+                    }`}
+                /></p>
+                <h3 className="faq-title"><FormattedMessage
+                    id="extensions.browserCompatibilityTitle"
+                    values={sharedValues}
+                /></h3>
+                <p><FormattedMessage
+                    id="extensions.browserCompatibilityText"
+                    values={sharedValues}
+                /></p></React.Fragment>)}
             {props.children}
             {!props.scratchLinkOnly && (
                 <React.Fragment>
@@ -44,6 +57,7 @@ const ExtensionTroubleshooting = props => {
 
 ExtensionTroubleshooting.propTypes = {
     children: PropTypes.node,
+    currentOS: PropTypes.string.isRequired,
     deviceName: PropTypes.string.isRequired,
     deviceNameShort: PropTypes.string,
     scratchLinkOnly: PropTypes.bool

--- a/src/components/extension-landing/install-scratch-link.jsx
+++ b/src/components/extension-landing/install-scratch-link.jsx
@@ -75,11 +75,6 @@ const InstallScratchLink = ({
                             }-toolbar.png`}
                         />
                     </span>
-                    <p className="step-description"><FormattedMessage
-                        id={`installScratchLink.startScratchLink2.${
-                            currentOS === OS_ENUM.WINDOWS ? 'Windows' : 'macOS'
-                        }`}
-                    /></p>
                 </Step>
                 <Step
                     compact

--- a/src/l10n.json
+++ b/src/l10n.json
@@ -169,8 +169,6 @@
     "installScratchLink.downloadAndInstall": "Download and install Scratch Link.",
     "installScratchLink.startScratchLink.macOS": "Start Scratch Link and make sure it is running. It should appear in your menu bar.",
     "installScratchLink.startScratchLink.Windows": "Start Scratch Link and make sure it is running. It should appear in your notification area (system tray).",
-    "installScratchLink.startScratchLink2.macOS": "If it does not appear, run Scratch Link from your Applications folder.",
-    "installScratchLink.startScratchLink2.Windows": "If it does not appear, run Scratch Link from your Start menu.",
     "installScratchLink.learnMore.bodyText": "To learn more about Scratch Link, click {linkText}.",
     "installScratchLink.learnMore.linkText": "here",
     "installScratchLink.ifYouHaveTrouble.bodyText": "If you have trouble, see the {linkText} for tips.",
@@ -446,6 +444,9 @@
     "helpWidget.confirmation": "Thank you for your message.",
 
     "extensions.troubleshootingTitle": "Troubleshooting",
+    "extensions.scratchLinkRunning": "Make sure Scratch Link is running",
+    "extensions.startScratchLink.macOS": "If Scratch Link does not appear in your menu bar, run Scratch Link from your Applications folder.",
+    "extensions.startScratchLink.Windows": "If Scratch Link does not appear in your notification area (system tray), run Scratch Link from your Start menu.",
     "extensions.browserCompatibilityTitle": "Make sure your browser is compatible with Scratch Link",
     "extensions.browserCompatibilityText": "Scratch Link is compatible with most browsers on macOS and Windows. For Safari, please update to Scratch Link 2.x, Safari 14 or newer, and macOS 10.15 or newer.",
     "extensions.checkOSVersionTitle": "Make sure your operating system is compatible with Scratch Link",

--- a/src/views/boost/boost.jsx
+++ b/src/views/boost/boost.jsx
@@ -193,7 +193,10 @@ class Boost extends ExtensionLanding {
                         />
                     </Steps>
                 </ExtensionSection>
-                <ExtensionTroubleshooting deviceName="BOOST">
+                <ExtensionTroubleshooting
+                    currentOS={this.state.OS}
+                    deviceName="BOOST"
+                >
                     {isDownloaded(this.state.OS) && (
                         <React.Fragment>
                             <h3 className="faq-title"><FormattedMessage id="boost.updateScratchLinkTitle" /></h3>

--- a/src/views/download/scratch-link/download.jsx
+++ b/src/views/download/scratch-link/download.jsx
@@ -103,6 +103,7 @@ const ScratchLink = ({intl}) => {
                 </div>
             </ExtensionSection>
             <ExtensionTroubleshooting
+                currentOS={os}
                 deviceName={intl.formatMessage({id: 'scratchLink.headerTitle'})}
                 scratchLinkOnly
             >

--- a/src/views/ev3/ev3.jsx
+++ b/src/views/ev3/ev3.jsx
@@ -283,6 +283,7 @@ class EV3 extends ExtensionLanding {
                     </Steps>
                 </ExtensionSection>
                 <ExtensionTroubleshooting
+                    currentOS={this.state.OS}
                     deviceName="EV3"
                     scratchLinkOnly // EV3 is Bluetooth Classic so it's only available through Scratch Link
                 >

--- a/src/views/gdxfor/gdxfor.jsx
+++ b/src/views/gdxfor/gdxfor.jsx
@@ -207,6 +207,7 @@ class GdxFor extends ExtensionLanding {
                     </Steps>
                 </ExtensionSection>
                 <ExtensionTroubleshooting
+                    currentOS={this.state.OS}
                     deviceName={this.props.intl.formatMessage({id: 'gdxfor.deviceName'})}
                     deviceNameShort={this.props.intl.formatMessage({id: 'gdxfor.deviceNameShort'})}
                 >

--- a/src/views/microbit/microbit.jsx
+++ b/src/views/microbit/microbit.jsx
@@ -319,7 +319,10 @@ class MicroBit extends ExtensionLanding {
                     </FlexRow>
                     <hr />
                 </ExtensionSection>
-                <ExtensionTroubleshooting deviceName="micro:bit">
+                <ExtensionTroubleshooting
+                    currentOS={this.state.OS}
+                    deviceName="micro:bit"
+                >
                     {isDownloaded(this.state.OS) && (
                         <React.Fragment>
                             <h3 className="faq-title"><FormattedMessage id="microbit.checkOSVersionTitle" /></h3>

--- a/src/views/wedo2/wedo2.jsx
+++ b/src/views/wedo2/wedo2.jsx
@@ -192,7 +192,10 @@ class Wedo2 extends ExtensionLanding {
                         />
                     </Steps>
                 </ExtensionSection>
-                <ExtensionTroubleshooting deviceName="WeDo 2.0">
+                <ExtensionTroubleshooting
+                    currentOS={this.state.OS}
+                    deviceName="WeDo 2.0"
+                >
                     {isDownloaded(this.state.OS) && (
                         <React.Fragment>
                             <h3 className="faq-title"><FormattedMessage id="wedo2.checkOSVersionTitle" /></h3>


### PR DESCRIPTION
### Resolves:

ENA-348

### Changes:

- Move "If [Scratch Link] does not appear" advice from the installation steps (`install-scratch-link.jsx`) down into the troubleshooting section (`extension-troubleshooting.jsx`).
- Add a `currentOS` property to the `ExtensionTroubleshooting` component, since this info is the first OS-specific content in that component.
- Now that `ExtensionTroubleshooting` has a `currentOS` property, it can make the browser compatibility item show only for platforms which connect to Scratch Link from a browser.

### Test Coverage:

Tested locally with multiple browsers on Windows 11.
