### PR TITLE
ci: configure Renovate to extend Scratch defaults

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -2,6 +2,6 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
 
   "extends": [
-    "github>LLK/scratch-renovate-config:conservative"
+    "github>scratchfoundation/scratch-renovate-config"
   ]
 }


### PR DESCRIPTION
### Proposed Changes

Update the Renovate config to extend [`scratchfoundation/scratch-renovate-config/default.json`](https://github.com/scratchfoundation/scratch-renovate-config/blob/main/default.json) instead of [`LLK/scratch-renovate-config/conservative.json`](https://github.com/LLK/scratch-renovate-config/blob/main/conservative.json).

### Reason for Changes

1. Replace `LLK` with `scratchfoundation` to reflect the new home of this repository
2. Moving from our "conservative" rule set to our default rule set should (after the initial flurry of CI/CD builds) keep us more up-to-date and reduce the number of open PRs that rebuild with new commits.
