### PR TITLE
Fix tests and improve test debugging

### DIFF
--- a/test/integration/footer-links.test.js
+++ b/test/integration/footer-links.test.js
@@ -132,7 +132,7 @@ describe('www-integration footer links', () => {
         expect(pathname).toMatch(/^\/cookies\/?$/);
 
         // Verify localization of last updated message
-        const lastUpdated = await findText('The Scratch Cookie Policy was last updated June 28, 2023');
+        const lastUpdated = await findText('The Scratch Cookie Policy was last updated');
         const lastUpdatedVisible = await lastUpdated.isDisplayed();
         expect(lastUpdatedVisible).toBe(true);
     });

--- a/test/integration/project-page.test.js
+++ b/test/integration/project-page.test.js
@@ -198,8 +198,8 @@ describe('www-integration project-creation signed in', () => {
         // SauceLabs doesn't have access to the sb3 used in 'load project from file' test
         // https://support.saucelabs.com/hc/en-us/articles/115003685593-Uploading-Files-to-a-Sauce-Labs-Virtual-Machine-during-a-Test
         if (remote) {
-            await driver.get('https://github.com/LLK/scratch-www/blob/develop/test/fixtures/project1.sb3');
-            await clickText('Download');
+            await driver.get('https://github.com/scratchfoundation/scratch-www/blob/develop/test/fixtures/project1.sb3');
+            await clickXpath('//Button[@data-testid="download-raw-button"]');
             await driver.sleep(3000);
         }
     });

--- a/test/integration/search.test.js
+++ b/test/integration/search.test.js
@@ -49,7 +49,7 @@ describe('www-integration search', () => {
         await searchBar.sendKeys(`100% pen${getKey('ENTER')}`);
 
         // switch to studios tab
-        clickXpath('//a/li/span[contains(text(),"Studios")]');
+        await clickXpath('//button//*[contains(text(),"Studios")]');
 
         // check url
         const url = await driver.getCurrentUrl();

--- a/test/integration/selenium-helpers.js
+++ b/test/integration/selenium-helpers.js
@@ -307,7 +307,7 @@ class SeleniumHelper {
     async waitUntilGone (element) {
         const outerError = new SeleniumHelperError('waitUntilGone failed', [{element}]);
         try {
-            await this.driver.wait(until.stalenessOf(element));
+            await this.driver.wait(until.stalenessOf(element), DEFAULT_TIMEOUT_MILLISECONDS);
         } catch (cause) {
             await outerError.collectContext(this.driver);
             throw outerError.chain(cause);
@@ -461,7 +461,7 @@ class SeleniumHelper {
     async urlMatches (regex) {
         const outerError = new SeleniumHelperError('urlMatches failed', [{regex}]);
         try {
-            await this.driver.wait(until.urlMatches(regex), 1000 * 5);
+            await this.driver.wait(until.urlMatches(regex), DEFAULT_TIMEOUT_MILLISECONDS);
         } catch (cause) {
             outerError.collectContext(this.driver);
             throw outerError.chain(cause);
@@ -527,7 +527,7 @@ class SeleniumHelper {
     static async waitUntilVisible (element, driver) {
         const outerError = new SeleniumHelperError('waitUntilVisible failed', [{element}]);
         try {
-            await driver.wait(until.elementIsVisible(element));
+            await driver.wait(until.elementIsVisible(element), DEFAULT_TIMEOUT_MILLISECONDS);
         } catch (cause) {
             outerError.collectContext(driver);
             throw outerError.chain(cause);


### PR DESCRIPTION
### Resolves:

Makes `scratch-www` integration tests reliable.

- Resolves #3038 and #3324 (or maybe those issues are already stale)

### Changes:

- Add `SeleniumHelperError` and a filter on `Error.prepareStackTrace` to improve debug info associated with test failures
- Adjust timeouts and messages for consistency throughout `SeleniumHelper` methods
- Fix a variety of specific problems with existing tests (I'll add inline comments on the PR)

### Test Coverage:

I tested these changes by temporarily telling CI to run integration tests without deploying. For example:
https://app.circleci.com/pipelines/github/scratchfoundation/scratch-www/12490/workflows/2a2a2dde-63ce-4f00-84c3-43025afa06c6/jobs/15681