### PR TITLE
ci: automatically build release branch

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -1,9 +1,8 @@
 name: CI/CD
 
 on:
-  pull_request: # Runs whenever a pull request is created or updated
   push: # Runs whenever a commit is pushed to the repository
-    branches: [master, develop, beta, hotfix/*] # ...on any of these branches
+  workflow_call: # Allows another workflow to call this one
   workflow_dispatch: # Allows you to run this workflow manually from the Actions tab
 
 concurrency:

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -7,8 +7,7 @@ on:
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-  # This workflow contains a single job called "build"
-  build:
+  make-branch-and-prs:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
 
@@ -48,3 +47,10 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           pr_allow_empty: true
 
+  # Actions taken by a workflow aren't allowed to automatically trigger the 'on' events of another workflow,
+  # so the CI/CD workflow is not triggered by the branch and PRs created above.
+  # Call it explicitly instead:
+  call-ci-cd:
+    needs: make-branch-and-prs
+    uses: ./.github/workflows/ci-cd.yml
+    secrets: inherit


### PR DESCRIPTION
### Changes:

With CCI, running the "Create release branch and PRs" workflow would automatically cause a build & deploy cycle.

With GHA, actions taken by one workflow won't automatically trigger another workflow. Because of that, the "Create release branch and PRs" workflow creates the branch and PRs but does not build and deploy the new branch as it did before. Earlier today, I waited for the "Create release branch" workflow to finish, and then I manually dispatched the CI/CD workflow to deploy the release branch for our testing session.

This change adds an explicit workflow call to make that happen automatically. This is similar to the logic in the "Daily TX Pull" workflow in `scratch-l10n`, for example.

### Test Coverage:

A full test won't be possible until the next time we create a release branch, but pushing this change and making a PR is a partial test.