### PR TITLE
fix: temporarily revert all routing changes for the new site

### DIFF
--- a/src/routes.json
+++ b/src/routes.json
@@ -3,7 +3,8 @@
         "name": "about",
         "pattern": "^/about/?$",
         "routeAlias": "/about/?$",
-        "redirect": "RADISH_URL/"
+        "view": "about/about",
+        "title": "About"
     },
     {
         "name": "annual-report",
@@ -104,6 +105,12 @@
         "viewportWidth": "device-width"
     },
     {
+        "name": "conference-index-2020",
+        "pattern": "^/conference/2020/?$",
+        "routeAlias": "/conference(?!/20[1-2][0-9])",
+        "redirect": "/conference/2021"
+    },
+    {
         "name": "conference-index-2021",
         "pattern": "^/conference/2021/?$",
         "routeAlias": "/conference(?!/20[1-2][0-9])",
@@ -127,19 +134,23 @@
         "name": "contact-us",
         "pattern": "^/contact-us/?(\\?.*)?$",
         "routeAlias": "/contact-us/?",
-        "redirect": "RADISH_URL/help-center/"
+        "view": "contact-us/contact-us",
+        "title": "Contact Us",
+        "viewportWidth": "device-width"
     },
     {
         "name": "cookies",
         "pattern": "^/cookies/?$",
         "routeAlias": "/cookies/?",
-        "redirect": "RADISH_URL/cookie-policy/"
+        "view": "cookies/cookies",
+        "title": "Cookie Policy"
     },
     {
         "name": "credits",
         "pattern": "^/credits/?$",
         "routeAlias": "/info/(cards|credits|faq|donate)/?$",
-        "redirect": "RADISH_URL/our-team-credits/"
+        "view": "credits/credits",
+        "title": "Credits"
     },
     {
         "name": "developers",
@@ -152,19 +163,22 @@
         "name": "dmca",
         "pattern": "^/DMCA/?$",
         "routeAlias": "/DMCA/?$",
-        "redirect": "RADISH_URL/42-0-dmca/"
+        "view": "dmca/dmca",
+        "title": "DMCA"
     },
     {
         "name": "download",
         "pattern": "^/download/?(\\?.*)?$",
         "routeAlias": "/download",
-        "redirect": "RADISH_URL/help-center/"
+        "view": "download/download",
+        "title": "Scratch Offline Editor"
     },
     {
         "name": "educator-landing",
         "pattern": "^/educators/?(\\?.*)?$",
         "routeAlias": "/educators(?:/(faq|register|waiting))?/?(\\?.*)?$",
-        "redirect": "RADISH_URL/scratch-for-educators/"
+        "view": "teachers/landing/landing",
+        "title": "Educators"
     },
     {
         "name": "ethics",
@@ -240,13 +254,21 @@
         "name": "parents",
         "pattern": "^/parents/?(\\?.*)?$",
         "routeAlias": "/parents/",
-        "redirect": "RADISH_URL/parents-caregivers/"
+        "view": "parents/parents",
+        "title": "For Parents"
+    },
+    {
+        "name": "preview-faq-redirect",
+        "pattern": "^/preview-faq/?$",
+        "routeAlias": "/preview-faq",
+        "redirect": "/3faq"
     },
     {
         "name": "privacypolicy",
         "pattern": "^/privacy_policy/?$",
         "routeAlias": "/privacy_policy/?$",
-        "redirect": "RADISH_URL/privacy-policy/"
+        "view": "privacypolicy/privacypolicy",
+        "title": "Privacy Policy"
     },
     {
         "name": "privacypolicy-apps",
@@ -377,7 +399,8 @@
         "name": "terms",
         "pattern": "^/terms_of_use/?$",
         "routeAlias": "/terms_of_use/?$",
-        "redirect": "RADISH_URL/privacy-policy/"
+        "view": "terms/terms",
+        "title": "Scratch Terms of Use"
     },
     {
         "name": "wedo2",
@@ -422,10 +445,16 @@
         "title": "LEGO BOOST"
     },
     {
+        "name":"3-faq-redirect",
+        "pattern": "^/3faq/?$",
+        "routeAlias": "/3faq/?$",
+        "redirect": "/faq#scratch3"
+    },
+    {
         "name" : "credits-redirect",
         "pattern": "^/info/credits/?$",
         "routeAlias": "/info/(cards|credits|faq|donate)/?$",
-        "redirect": "RADISH_URL/our-team-credits/"
+        "redirect" : "/credits"
     },
     {
         "name" : "faq-redirect",
@@ -487,6 +516,12 @@
         "redirect": "/ideas"
     },
     {
+        "name": "hoc2014-redirect",
+        "pattern": "^/hoc2014/?(\\?.*)?$",
+        "routeAlias": "/hoc2014/?\\??",
+        "redirect": "/ideas"
+    },
+    {
         "name": "info-redirect",
         "pattern": "^/info/?(\\?.*)?$",
         "routeAlias": "/info/?(\\?.*)?$",
@@ -514,7 +549,7 @@
         "name": "sec-redirect",
         "pattern": "^/sec/?$",
         "routeAlias": "/sec",
-        "redirect": "RADISH_URL/scratch-education-collaborative/"
+        "redirect": "https://sip.scratch.mit.edu/sec"
     },
     {
         "name": "splash-redirect",


### PR DESCRIPTION
### Changes:

Temporarily reset `routes.json` to the state it was in before any redirects related to our new website.
This should give us some breathing room to implement and test a proper fix tomorrow/later.