### PR TITLE
Fix project badges by correcting Buffer polyfill

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -108,7 +108,7 @@ module.exports = {
     resolve: {
         fallback: {
             // Node modules are no longer polyfilled by default in Webpack 5, so we need to add these here
-            buffer: require.resolve('buffer/'),
+            Buffer: require.resolve('buffer/'),
             stream: require.resolve('stream-browserify') // jszip
         },
         symlinks: false // Fix local development with `npm link` packages
@@ -200,6 +200,9 @@ module.exports = {
         new EmitFilePlugin({
             filename: 'version.txt',
             content: getVersionId
+        }),
+        new webpack.ProvidePlugin({
+            Buffer: ['buffer', 'Buffer']
         })
     ].concat(pageRoutes
         .map(route => new HtmlWebpackPlugin(defaults({}, {


### PR DESCRIPTION
### Resolves:

ENG-458 Extension Badges failing to appear on project pages

### Changes:

Fix the incorrect `Buffer` polyfill configuration in `webpack.config.js`. This polyfill is required because webpack 5 no longer automatically polyfills all the things that webpack 4 did in the past.

See also: <https://viglucci.io/articles/how-to-polyfill-buffer-with-webpack-5>

The incorrect `Buffer` polyfill was roughly equivalent to no `Buffer` polyfill, leading to this error, which you can see in your browser console by visiting any project page in production right now:
```text
www Unhandled project parsing error: ReferenceError: Buffer is not defined
```

That error was coming from the code that parses the project information to create those badges. Honestly, I was a little surprised that a) this was so easy to track down, and b) there aren't other, more dramatic problems due to the lack of `Buffer`.

### Test Coverage:

Tested manually in our staging environment.
