### PR TITLE
feat: uepr-72: Add dsa requirements link to footer

### DIFF
--- a/src/components/footer/www/footer.jsx
+++ b/src/components/footer/www/footer.jsx
@@ -179,6 +179,11 @@ const Footer = props => (
                             <FormattedMessage id="general.dmca" />
                         </a>
                     </dd>
+                    <dd>
+                        <a href="https://www.scratchfoundation.org/DSA/">
+                            <FormattedMessage id="general.dsa" />
+                        </a>
+                    </dd>
                 </dl>
 
                 <dl>

--- a/src/l10n.json
+++ b/src/l10n.json
@@ -27,6 +27,7 @@
     "general.credits": "Our Team",
     "general.donors": "Donors",
     "general.dmca": "DMCA",
+    "general.dsa": "DSA requirements",
     "general.emailAddress": "Email address",
     "general.english": "English",
     "general.error": "Oops! Something went wrong",

--- a/test/integration/footer-links.test.js
+++ b/test/integration/footer-links.test.js
@@ -160,6 +160,13 @@ describe('www-integration footer links', () => {
         const pathname = (new URL(url)).pathname;
         expect(pathname).toMatch(/^\/DMCA\/?$/);
     });
+
+    test('click DSA requirements link', async () => {
+        await clickText('DSA requirements');
+        await waitUntilDocumentReady();
+        const url = await driver.getCurrentUrl();
+        expect(url).toMatch(/^https:\/\/www.scratchfoundation.org\/DSA\/$/);
+    });
 });
 
 // The following links in the footer are skipped because they are not part of scratch-www


### PR DESCRIPTION
### Resolves:

https://scratchfoundation.atlassian.net/browse/UEPR-72

### Changes:

Add a link in the footer pointing to https://scratchfoundation.org/DSA/

### Test Coverage:

Added an integration test for the existence of the link
