### PR TITLE
ci: add job to push Transifex strings

### DIFF
--- a/.github/workflows/tx-push.yml
+++ b/.github/workflows/tx-push.yml
@@ -1,0 +1,26 @@
+name: Transifex Push
+
+on:
+  push: # Runs whenever a commit is pushed to the repository
+    branches: [master, develop, release/*] # ...on any of these branches
+  workflow_dispatch: # Allows you to run this workflow manually from the Actions tab
+
+jobs:
+  transifex-push:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
+      - uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4
+        with:
+          cache: 'npm'
+          node-version-file: '.nvmrc'
+      - name: info
+        run: |
+          echo "Scratch environment: ${{ vars.SCRATCH_ENV }}"
+          echo "Node version: $(node --version)"
+          echo "NPM version: $(npm --version)"
+      - run: npm ci
+      - name: push strings to Transifex
+        run: npm run i18n:push --execute
+        env:
+          TX_TOKEN: ${{ secrets.TX_TOKEN }}

--- a/bin/tx-push-www
+++ b/bin/tx-push-www
@@ -69,7 +69,7 @@ glob('src/views/**/l10n.json', {}, function (er, files) {
 
     let cmd;
     resources.forEach(resource => {
-        cmd = `$(npm bin)/tx-push-src scratch-website ${resource.resourceName} ${resource.filename}`;
+        cmd = `tx-push-src scratch-website ${resource.resourceName} ${resource.filename}`;
         if (execute) {
             // push all the source files to transifex - force update
             process.stdout.write(`running command: ${cmd}\n`);


### PR DESCRIPTION
### Changes:

- Add a new GHA workflow to run the `i18:push` npm script
- Fix (remove) the path to `tx-push-src` in the `tx-push-www` script

The new workflow is triggered on push to `develop`, `master`, and release branches. Back when we used Travis, we had it set up on an interval. I think this approach will still push any time we need it, but probably still less often than our Travis approach.