### PR TITLE
fix: display guide from learn how to make project button

### DIFF
--- a/src/components/welcome/welcome.jsx
+++ b/src/components/welcome/welcome.jsx
@@ -1,5 +1,6 @@
 const PropTypes = require('prop-types');
 const React = require('react');
+const {shouldDisplayOnboarding} = require('../../lib/onboarding.js');
 
 const Box = require('../box/box.jsx');
 
@@ -19,11 +20,23 @@ const Welcome = props => (
     >
         <div className="welcome-col blue">
             <h4>
-                <a href="/projects/editor/?tutorial=getStarted">
+                <a
+                    href={
+                        shouldDisplayOnboarding(props.user, props.permissions) ?
+                            '/projects/editor/' :
+                            '/projects/editor/?tutorial=getStarted'
+                    }
+                >
                     {props.messages['welcome.learn']}
                 </a>
             </h4>
-            <a href="/projects/editor/?tutorial=getStarted">
+            <a
+                href={
+                    shouldDisplayOnboarding(props.user, props.permissions) ?
+                        '/projects/editor/' :
+                        '/projects/editor/?tutorial=getStarted'
+                }
+            >
                 <img
                     alt="Get Started"
                     src="/images/welcome-learn.png"
@@ -66,7 +79,9 @@ Welcome.propTypes = {
         'welcome.tryOut': PropTypes.string,
         'welcome.connect': PropTypes.string
     }),
-    onDismiss: PropTypes.func
+    onDismiss: PropTypes.func,
+    permissions: PropTypes.object,
+    user: PropTypes.object
 };
 
 Welcome.defaultProps = {

--- a/src/views/splash/presentation.jsx
+++ b/src/views/splash/presentation.jsx
@@ -418,6 +418,8 @@ class SplashPresentation extends React.Component { // eslint-disable-line react/
                                     onDismiss={() => { // eslint-disable-line react/jsx-no-bind
                                         this.props.onDismiss('welcome');
                                     }}
+                                    permissions={this.props.permissions}
+                                    user={this.props.user}
                                 />
                             ] : [
                                 <WrappedActivityList
@@ -544,6 +546,7 @@ SplashPresentation.propTypes = {
     onDismiss: PropTypes.func.isRequired,
     onOpenAdminPanel: PropTypes.func.isRequired,
     onRefreshHomepageCache: PropTypes.func.isRequired,
+    permissions: PropTypes.object,
     refreshCacheStatus: PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types
     sessionStatus: PropTypes.string.isRequired,
     sharedByFollowing: PropTypes.arrayOf(PropTypes.object),

--- a/src/views/splash/splash.jsx
+++ b/src/views/splash/splash.jsx
@@ -218,6 +218,7 @@ class Splash extends React.Component {
                 isEducator={this.props.isEducator}
                 lovedByFollowing={this.props.loved}
                 news={this.state.news}
+                permissions={this.props.permissions}
                 refreshCacheStatus={homepageRefreshStatus}
                 sessionStatus={this.props.sessionStatus}
                 sharedByFollowing={this.props.shared}
@@ -267,6 +268,7 @@ Splash.propTypes = {
     isAdmin: PropTypes.bool,
     isEducator: PropTypes.bool,
     loved: PropTypes.arrayOf(PropTypes.object).isRequired,
+    permissions: PropTypes.object,
     refreshSession: PropTypes.func.isRequired,
     reviewCommunityGuidelines: PropTypes.func.isRequired,
     sessionStatus: PropTypes.string,
@@ -302,6 +304,7 @@ const mapStateToProps = state => ({
     isAdmin: state.permissions.admin,
     isEducator: state.permissions.educator,
     loved: state.splash.loved.rows,
+    permissions: state.permissions,
     sessionStatus: state.session.status,
     shared: state.splash.shared.rows,
     studios: state.splash.studios.rows,


### PR DESCRIPTION
### Changes:

Display guide to users when they select the "Learn how to make a project" button from the welcome screen if the user is eligible to view the guides
