### PR TITLE
fix: update "For Parents" video ID

### DIFF
--- a/src/views/parents/parents.jsx
+++ b/src/views/parents/parents.jsx
@@ -10,6 +10,9 @@ const render = require('../../lib/render.jsx');
 
 require('./parents.scss');
 
+// YouTube video ID for the embedded "What is Scratch?" video
+const videoId = 'LjOfOQkpPnU';
+
 const Landing = () => {
     const isParentConfirmingChildEmail = React.useMemo(() => {
         const query = window.location.search;
@@ -48,7 +51,7 @@ const Landing = () => {
                         <iframe
                             allowFullScreen
                             frameBorder="0"
-                            src="https://www.youtube.com/embed/jXUZaf5D12A"
+                            src={`https://www.youtube.com/embed/${videoId}`}
                         />
                     </div>
                 </FlexRow>


### PR DESCRIPTION
### Changes:

There's a new version of the "What is Scratch?" video. This change updates the ID used to embed that video at the top of the "For Parents" page.

I pulled the video ID out into a variable and added a comment with search terms so that it's easier to find (if there is a) next time.