### PR TITLE
feat: [UEPR-115] Show inappropriate link in freshdesk widget on contact us page

### DIFF
--- a/src/components/helpwidget/helpwidget.jsx
+++ b/src/components/helpwidget/helpwidget.jsx
@@ -95,9 +95,6 @@ class HelpWidget extends React.Component {
         };
         window.FreshworksWidget('setLabels', labels);
 
-        window.FreshworksWidget('disable', 'ticketForm', ['custom_fields.cf_inappropriate_report_link']);
-        window.FreshworksWidget('hide', 'ticketForm', ['custom_fields.cf_inappropriate_report_link']);
-
         // open the popup already on the form if passed Inappropriate content param
         this.openPopup(this.props.subject !== '');
     }


### PR DESCRIPTION
**Ticket:**
[UEPR-105](https://scratchfoundation.atlassian.net/jira/software/c/projects/UEPR/boards/92?selectedIssue=UEPR-105)

**Changes:**
Removed the code that hides the inappropriate report link in widget on Contact us page

![image](https://github.com/user-attachments/assets/487081ac-0116-4329-8ad5-883033034c1c)


[UEPR-105]: https://scratchfoundation.atlassian.net/browse/UEPR-105?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ