### PR TITLE
fix: make button transparent when there is no text in modal navigatio…

### DIFF
--- a/src/components/modal-navigation/modal-navigation.jsx
+++ b/src/components/modal-navigation/modal-navigation.jsx
@@ -40,7 +40,8 @@ const ModalNavigation = ({
                 <Button
                     onClick={onBackPage}
                     className={classNames('navigation-button', {
-                        hidden: !onBackPage
+                        hidden: !onBackPage,
+                        transparent: !prevButtonText
                     })}
                 >
                     <img
@@ -58,7 +59,9 @@ const ModalNavigation = ({
             </div>}
             <Button
                 onClick={onNextPage}
-                className={'navigation-button'}
+                className={classNames('navigation-button', {
+                    transparent: !nextButtonText
+                })}
             >
                 <span className="navText">
                     {nextButtonText}


### PR DESCRIPTION
Button are transparent in the downloadable cards modal in the ideas page where there are only arrows.