### PR TITLE
Improve contrast for Search.

### DIFF
--- a/src/views/search/search.scss
+++ b/src/views/search/search.scss
@@ -12,7 +12,7 @@ $base-bg: $ui-white;
     .title-banner {
         &.masthead {
             margin-bottom: 0;
-            background-color: $ui-blue-dark;
+            background-color: #714eb6;
             padding: 0;
 
             h1 {


### PR DESCRIPTION
Improve contrast of the banner (the thing that says "Search") was blue instead of purple.

### Resolves:

Poor contrast for search banner.

### Changes:

BG color from blue to purple.

### Test Coverage:

![Screenshot 2025-01-07 6 10 06 AM](https://github.com/user-attachments/assets/24fd81f2-f6d3-4731-89dc-f73734c9b374)
