### PR TITLE
Hotfix/cicd workflow python setup

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -58,10 +58,11 @@ jobs:
           EOF
       - name: setup Python
         if: ${{ env.SCRATCH_SHOULD_DEPLOY == 'true' }}
-        run: |
-          curl https://bootstrap.pypa.io/pip/3.5/get-pip.py -o get-pip.py
-          python3 get-pip.py pip==21.0.1
-          pip install s3cmd==2.3.0
+        uses: actions/setup-python@v5
+        with:
+          python-version: '^3.5'
+      - run: pip install s3cmd==2.3.0
+        if: ${{ env.SCRATCH_SHOULD_DEPLOY == 'true' }}
       - run: npm --production=false ci
       - run: mkdir -p ./test/results
       - name: lint

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -56,10 +56,14 @@ jobs:
           github.head_ref: ${{ github.head_ref }}
           github.ref: ${{ github.ref }}
           EOF
-      - name: setup
+      - name: setup Python
+        if: ${{ env.SCRATCH_SHOULD_DEPLOY == 'true' }}
         run: |
-          npm --production=false ci
-          mkdir -p ./test/results
+          curl https://bootstrap.pypa.io/pip/3.5/get-pip.py -o get-pip.py
+          python3 get-pip.py pip==21.0.1
+          pip install s3cmd==2.3.0
+      - run: npm --production=false ci
+      - run: mkdir -p ./test/results
       - name: lint
         run: npm run test:lint:ci
       - name: build
@@ -89,12 +93,6 @@ jobs:
           JEST_JUNIT_OUTPUT_NAME=localization-jest-results.xml npm run test:unit:jest:localization -- --reporters=jest-junit
           npm run test:unit:tap -- --output-file ./test/results/unit-raw.tap
           npm run test:unit:convertReportToXunit
-      - name: setup Python
-        if: ${{ env.SCRATCH_SHOULD_DEPLOY == 'true' }}
-        run: |
-          curl https://bootstrap.pypa.io/pip/3.5/get-pip.py -o get-pip.py
-          python3 get-pip.py pip==21.0.1
-          pip install s3cmd==2.3.0
       - name: deploy
         if: ${{ env.SCRATCH_SHOULD_DEPLOY == 'true' }}
         run: npm run deploy

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -57,12 +57,10 @@ jobs:
           github.ref: ${{ github.ref }}
           EOF
       - name: setup Python
-        if: ${{ env.SCRATCH_SHOULD_DEPLOY == 'true' }}
         uses: actions/setup-python@v5
         with:
           python-version: '^3.5'
       - run: pip install s3cmd==2.3.0
-        if: ${{ env.SCRATCH_SHOULD_DEPLOY == 'true' }}
       - run: npm --production=false ci
       - run: mkdir -p ./test/results
       - name: lint


### PR DESCRIPTION
### Resolves:

Resolves the current build failure preventing both staging and production deploys.

### Changes:

Before:
* If we plan to deploy,
   1. Install a version of `pip` that is compatible with Python 3.5, then
   2. Use `pip` to install `s3cmd==2.3.0`

After:
1. Use `actions/setup-python` to ensure availability of a version of Python that is compatible with v3.5, then
2. Use `pip` to install `s3cmd==2.3.0`

Since these commands are relatively quick, I moved them earlier in the workflow. Also, while they're only necessary in the case of a deploy, running them even when not deploying means that if a PR breaks them, we'll know about it before we try to deploy.

### Test Coverage:

Tested by manually running the GHA workflow on the branch. See also the checks on this PR.