### PR TITLE
fix: reintroduce ubuntu-22 as workflow version

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -19,7 +19,7 @@ env:
 
 jobs:
   build-and-test-and-maybe-deploy:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     environment: >-
       ${{
         (


### PR DESCRIPTION
### Resolves:
GitHub workflow failing

### Changes:
https://github.com/actions/runner-images/issues/10636 - the default Ubuntu version for Github workflows changed from 22 to 24. This introduces a new python version, which is not compativle with s3cmd. As a temporary solution bring back the older ubuntu version to preserve the same workflow behaviour until a more permament solution is implemented.

### Test Coverage:

_Please show how you have added tests to cover your changes or describe how you have tested the changes (include a screenshot if possible)._
