### PR TITLE
Fix s3cmd deploy on ubuntu-latest

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -58,10 +58,11 @@ jobs:
           EOF
       - name: setup Python
         if: ${{ env.SCRATCH_SHOULD_DEPLOY == 'true' }}
-        run: |
-          curl https://bootstrap.pypa.io/pip/3.5/get-pip.py -o get-pip.py
-          python3 get-pip.py pip==21.0.1
-          pip install s3cmd==2.3.0
+        uses: actions/setup-python@v5
+        with:
+          python-version: '^3.5'
+      - run: pip install s3cmd==2.3.0
+        if: ${{ env.SCRATCH_SHOULD_DEPLOY == 'true' }}
       - run: npm --production=false ci
       - run: mkdir -p ./test/results
       - name: lint

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -56,10 +56,14 @@ jobs:
           github.head_ref: ${{ github.head_ref }}
           github.ref: ${{ github.ref }}
           EOF
-      - name: setup
+      - name: setup Python
+        if: ${{ env.SCRATCH_SHOULD_DEPLOY == 'true' }}
         run: |
-          npm --production=false ci
-          mkdir -p ./test/results
+          curl https://bootstrap.pypa.io/pip/3.5/get-pip.py -o get-pip.py
+          python3 get-pip.py pip==21.0.1
+          pip install s3cmd==2.3.0
+      - run: npm --production=false ci
+      - run: mkdir -p ./test/results
       - name: lint
         run: npm run test:lint:ci
       - name: build
@@ -89,12 +93,6 @@ jobs:
           JEST_JUNIT_OUTPUT_NAME=localization-jest-results.xml npm run test:unit:jest:localization -- --reporters=jest-junit
           npm run test:unit:tap -- --output-file ./test/results/unit-raw.tap
           npm run test:unit:convertReportToXunit
-      - name: setup Python
-        if: ${{ env.SCRATCH_SHOULD_DEPLOY == 'true' }}
-        run: |
-          curl https://bootstrap.pypa.io/pip/3.5/get-pip.py -o get-pip.py
-          python3 get-pip.py pip==21.0.1
-          pip install s3cmd==2.3.0
       - name: deploy
         if: ${{ env.SCRATCH_SHOULD_DEPLOY == 'true' }}
         run: npm run deploy

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -59,8 +59,8 @@ jobs:
       - name: setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: '^3.5'
-      - run: pip install s3cmd==2.3.0
+          python-version: '3.12'
+      - run: pip install s3cmd==2.4.0
       - run: npm --production=false ci
       - run: mkdir -p ./test/results
       - name: lint

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -19,7 +19,7 @@ env:
 
 jobs:
   build-and-test-and-maybe-deploy:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     environment: >-
       ${{
         (

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -57,12 +57,10 @@ jobs:
           github.ref: ${{ github.ref }}
           EOF
       - name: setup Python
-        if: ${{ env.SCRATCH_SHOULD_DEPLOY == 'true' }}
         uses: actions/setup-python@v5
         with:
           python-version: '^3.5'
       - run: pip install s3cmd==2.3.0
-        if: ${{ env.SCRATCH_SHOULD_DEPLOY == 'true' }}
       - run: npm --production=false ci
       - run: mkdir -p ./test/results
       - name: lint


### PR DESCRIPTION
### Changes:

- Move the `ci-cd.yml` workflow back to `ubuntu-latest` (see scratchfoundation/scratch-www#9127)
- Use `s3cmd` version 2.4.0 (current latest) and Python 3.12 (the latest Python that is officially compatible with `s3cmd` 2.4.0)

#### Reasoning:

GHA's `ubuntu-latest` tag recently moved from Ubuntu 22 to Ubuntu 24. GHA's `ubuntu-24.04` image includes several versions of Python, but it defaults to Python 3.12 (and does not include Python 3.5). This caused our deploys to stop working for at least two reasons:

1. We were installing `pip` via a script that was designed specifically for Python 3.5
   * The script was downloaded from this hard-coded URL: <https://bootstrap.pypa.io/pip/3.5/get-pip.py>
   * This script is no longer compatible with Python 3.12
2. We were installing `pip` version 21.0.1, specifically
3. We were then using `pip` to install `s3cmd` at version 2.3.0, specifically
   * This version of `s3cmd` is no longer compatible with Python 3.12

We fixed the `pip` installation issue with scratchfoundation/scratch-www#9123, which exposed the `s3cmd` incompatibility.

For the sake of getting our in-progress deploy to work, we temporarily specified `ubuntu-22.04` (see scratchfoundation/scratch-www#9127).

The changes in this new PR move `ci-cd.yml` [back to](https://upload.wikimedia.org/wikipedia/en/d/d2/Back_to_the_Future.jpg) Unbuntu 24 by changing `runs-on` back to `ubuntu-latest`. We still use the `setup-python` action as introduced by scratchfoundation/scratch-www#9123, but we now specify Python 3.12 exactly. We also get `pip` for free.

Upgrading `s3cmd` to version 2.4.0 adds Python 3.12 compatibility. Combined with Python 3.12 from above, this means our deploys should work again.
