### PR TITLE
Add Sprites back to guidelines

### DIFF
--- a/src/views/guidelines/guidelines.jsx
+++ b/src/views/guidelines/guidelines.jsx
@@ -167,6 +167,7 @@ const Guidelines = () => {
                                 alt={intl.formatMessage({id: sectionImgAltTextId})}
                                 src={sectionImgSrc}
                             />
+                            <img>https://cdn.scratch.mit.edu/scratchr2/static/images/help/spritesforcommunityguid.png</img>
                         </div>
                     )
                 )}


### PR DESCRIPTION
https://scratch.mit.edu/discuss/topic/798979/ for this

### Resolves:

nothing

### Changes:

Sprites icon back in guidelines 

### Test Coverage:

nothing.