### PR TITLE
Hotfix: MIT Accessibility link

### DIFF
--- a/src/components/footer/www/footer.jsx
+++ b/src/components/footer/www/footer.jsx
@@ -184,6 +184,11 @@ const Footer = props => (
                             <FormattedMessage id="general.dsa" />
                         </a>
                     </dd>
+                    <dd>
+                        <a href="https://accessibility.mit.edu/">
+                            <FormattedMessage id="general.mitAccessibility" />
+                        </a>
+                    </dd>
                 </dl>
 
                 <dl>

--- a/src/l10n.json
+++ b/src/l10n.json
@@ -49,6 +49,7 @@
     "general.learnMore": "Learn More",
     "general.male": "Male",
     "general.messages": "Messages",
+    "general.mitAccessibility": "MIT Accessibility",
     "general.month": "Month",
     "general.monthJanuary": "January",
     "general.monthFebruary": "February",

--- a/test/integration/footer-links.test.js
+++ b/test/integration/footer-links.test.js
@@ -171,6 +171,13 @@ describe('www-integration footer links', () => {
         const pocTextVisible = await pocText.isDisplayed();
         expect(pocTextVisible).toBeTruthy();
     });
+
+    test('click MIT Accessibility link', async () => {
+        await clickText('MIT Accessibility');
+        await waitUntilDocumentReady();
+        const url = await driver.getCurrentUrl();
+        expect(url).toBe('https://accessibility.mit.edu/');
+    });
 });
 
 // The following links in the footer are skipped because they are not part of scratch-www


### PR DESCRIPTION
### Resolves:

MIT now requires that pages hosted on domains ending in `mit.edu` link to their Accessibility site.

- Closes #9129 
  - ~All changes from #9129 are included here so that we can... y'know... deploy at all.~ These were merged separately

### Changes:

Add a footer link to the MIT Accessibility site.

### Test Coverage:

This PR adds one new test, which verifies that clicking the link goes to the expected site.