### PR TITLE
feat: [UEPR-54] update to scoped dependency for scratch-gui

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ The scratch-www project has lots of aspects of its design that are particular to
 To use it for your own project, you would have to look at all the places it makes backend calls, and
 create your own backend systems to perform those functions.
 
-The [scratch-gui](https://github.com/scratchfoundation/scratch-gui) project, on the other hand, is designed to be
+The [scratch-gui](https://github.com/scratchfoundation/scratch-editor/tree/develop/packages/scratch-gui) project, on the other hand, is designed to be
 able to be used by anyone, without needing to create backend systems, though it also can support
 backend systems for project and asset saving.
 
@@ -33,12 +33,12 @@ We welcome your contributions to this codebase! You may want to start by browsin
 list of open issues labeled "help wanted"](https://github.com/scratchfoundation/scratch-www/issues?q=is%3Aopen+is%3Aissue+label%3A%22help+wanted%22).
 
 Contributing to scratch-www can be more difficult than contributing to
-[scratch-gui](https://github.com/scratchfoundation/scratch-gui). This is because scratch-gui can be run on its
+[scratch-gui](https://github.com/scratchfoundation/scratch-editor/tree/develop/packages/scratch-gui). This is because scratch-gui can be run on its
 own, without needing any other services to be running, while scratch-www needs to communicate
 with several backend systems that the Scratch team runs (see "How this fits in with other Scratch
 repos" above). If you are new to contributing to Scratch's source code, we suggest you start
 by becoming familiar with scratch-gui and its [list of open issues labeled "help
-wanted"](https://github.com/scratchfoundation/scratch-gui/issues?q=is%3Aopen+is%3Aissue+label%3A%22help+wanted%22).
+wanted"](https://github.com/scratchfoundation/scratch-editor/issues?q=is%3Aopen+is%3Aissue+label%3A%22help+wanted%22).
 
 To contribute, please follow the [standard steps for contributing to a project on
 GitHub](https://github.com/firstcontributions/first-contributions).

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "react-twitter-embed": "3.0.3",
         "react-use": "17.6.0",
         "scratch-parser": "6.0.0",
-        "scratch-storage": "2.3.284"
+        "scratch-storage": "^4.0.1"
       },
       "devDependencies": {
         "@babel/cli": "7.26.4",
@@ -39,6 +39,7 @@
         "@formatjs/intl-numberformat": "8.15.2",
         "@formatjs/intl-pluralrules": "5.4.2",
         "@formatjs/intl-relativetimeformat": "11.4.9",
+        "@scratch/scratch-gui": "^11.0.0-beta.2",
         "@types/jest": "29.5.14",
         "async": "3.2.6",
         "autoprefixer": "10.4.20",
@@ -111,7 +112,6 @@
         "regenerator-runtime": "0.13.9",
         "sass": "1.83.4",
         "sass-loader": "10.5.2",
-        "scratch-gui": "5.1.33",
         "scratch-l10n": "5.0.101",
         "selenium-webdriver": "4.28.1",
         "slick-carousel": "1.8.1",
@@ -3875,6 +3875,475 @@
         "node": ">=8.0.0"
       }
     },
+    "node_modules/@scratch/scratch-gui": {
+      "version": "11.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/@scratch/scratch-gui/-/scratch-gui-11.0.0-beta.2.tgz",
+      "integrity": "sha512-U3WAWq7WQq1VR9WpKyGnzzFyiuP8V6FQfji2IDYQMI5STDcZBBV8QpT3vBFCs72e9rdXHprsruOvYpf0HZvzIw==",
+      "dev": true,
+      "dependencies": {
+        "@microbit/microbit-universal-hex": "^0.2.2",
+        "@scratch/scratch-render": "11.0.0-beta.2",
+        "@scratch/scratch-svg-renderer": "11.0.0-beta.2",
+        "@scratch/scratch-vm": "11.0.0-beta.2",
+        "arraybuffer-loader": "^1.0.6",
+        "autoprefixer": "^9.0.1",
+        "balance-text": "^3.3.1",
+        "base64-loader": "^1.0.0",
+        "bowser": "^1.9.4",
+        "cat-blocks": "npm:scratch-blocks@0.1.0-prerelease.20220318143026",
+        "classnames": "^2.2.6",
+        "computed-style-to-inline-style": "^3.0.0",
+        "cookie": "^0.6.0",
+        "copy-webpack-plugin": "^6.4.1",
+        "core-js": "^2.5.7",
+        "css-loader": "5.2.7",
+        "dapjs": "^2.3.0",
+        "es6-object-assign": "^1.1.0",
+        "get-float-time-domain-data": "^0.1.0",
+        "get-user-media-promise": "^1.1.4",
+        "immutable": "^3.8.2",
+        "intl": "^1.2.5",
+        "js-base64": "^2.4.9",
+        "keymirror": "^0.1.1",
+        "lodash.bindall": "^4.4.0",
+        "lodash.debounce": "^4.0.8",
+        "lodash.defaultsdeep": "^4.6.1",
+        "lodash.omit": "^4.5.0",
+        "lodash.throttle": "^4.0.1",
+        "minilog": "^3.1.0",
+        "omggif": "^1.0.9",
+        "papaparse": "^5.3.0",
+        "postcss-import": "^12.0.0",
+        "postcss-loader": "4.3.0",
+        "postcss-simple-vars": "^5.0.1",
+        "prop-types": "^15.5.10",
+        "query-string": "^5.1.1",
+        "raw-loader": "^4.0.0",
+        "react-contextmenu": "^2.9.4",
+        "react-draggable": "^3.0.5",
+        "react-ga": "^2.5.3",
+        "react-intl": "^2.9.0",
+        "react-modal": "^3.9.1",
+        "react-popover": "^0.5.10",
+        "react-responsive": "^5.0.0",
+        "react-style-proptype": "^3.2.2",
+        "react-tabs": "^2.3.0",
+        "react-tooltip": "^4.5.1",
+        "react-virtualized": "^9.20.1",
+        "redux-throttle": "^0.1.1",
+        "scratch-audio": "^1.0.0",
+        "scratch-blocks": "^1.1.6",
+        "scratch-l10n": "^3.18.3",
+        "scratch-paint": "^2.2.151",
+        "scratch-render-fonts": "^1.0.2",
+        "scratch-storage": "^4.0.24",
+        "startaudiocontext": "^1.2.1",
+        "style-loader": "4.0.0",
+        "text-encoding": "^0.7.0",
+        "to-style": "^1.3.3",
+        "wav-encoder": "^1.3.0",
+        "xhr": "^2.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.0.0",
+        "react-dom": "^16.0.0",
+        "react-redux": "^5.0.7",
+        "redux": "^3.7.2"
+      }
+    },
+    "node_modules/@scratch/scratch-gui/node_modules/autoprefixer": {
+      "version": "9.8.8",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-9.8.8.tgz",
+      "integrity": "sha512-eM9d/swFopRt5gdJ7jrpCwgvEMIayITpojhkkSMRsFHYuH5bkSQ4p/9qTEHtmNudUZh22Tehu7I6CxAW0IXTKA==",
+      "dev": true,
+      "dependencies": {
+        "browserslist": "^4.12.0",
+        "caniuse-lite": "^1.0.30001109",
+        "normalize-range": "^0.1.2",
+        "num2fraction": "^1.2.2",
+        "picocolors": "^0.2.1",
+        "postcss": "^7.0.32",
+        "postcss-value-parser": "^4.1.0"
+      },
+      "bin": {
+        "autoprefixer": "bin/autoprefixer"
+      },
+      "funding": {
+        "type": "tidelift",
+        "url": "https://tidelift.com/funding/github/npm/autoprefixer"
+      }
+    },
+    "node_modules/@scratch/scratch-gui/node_modules/cookie": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.6.0.tgz",
+      "integrity": "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@scratch/scratch-gui/node_modules/core-js": {
+      "version": "2.6.12",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
+      "integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==",
+      "deprecated": "core-js@<3.23.3 is no longer maintained and not recommended for usage due to the number of issues. Because of the V8 engine whims, feature detection in old core-js versions could cause a slowdown up to 100x even if nothing is polyfilled. Some versions have web compatibility issues. Please, upgrade your dependencies to the actual version of core-js.",
+      "dev": true,
+      "hasInstallScript": true
+    },
+    "node_modules/@scratch/scratch-gui/node_modules/decode-uri-component": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.2.tgz",
+      "integrity": "sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/@scratch/scratch-gui/node_modules/immutable": {
+      "version": "3.8.2",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-3.8.2.tgz",
+      "integrity": "sha512-15gZoQ38eYjEjxkorfbcgBKBL6R7T459OuK+CpcWt7O3KF4uPCx2tD0uFETlUDIyo+1789crbMhTvQBSR5yBMg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/@scratch/scratch-gui/node_modules/intl-messageformat": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-2.2.0.tgz",
+      "integrity": "sha512-I+tSvHnXqJYjDfNmY95tpFMj30yoakC6OXAo+wu/wTMy6tA/4Fd4mvV7Uzs4cqK/Ap29sHhwjcY+78a8eifcXw==",
+      "dev": true,
+      "dependencies": {
+        "intl-messageformat-parser": "1.4.0"
+      }
+    },
+    "node_modules/@scratch/scratch-gui/node_modules/intl-messageformat-parser": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/intl-messageformat-parser/-/intl-messageformat-parser-1.4.0.tgz",
+      "integrity": "sha512-/XkqFHKezO6UcF4Av2/Lzfrez18R0jyw7kRFhSeB/YRakdrgSc9QfFZUwNJI9swMwMoNPygK1ArC5wdFSjPw+A==",
+      "deprecated": "We've written a new parser that's 6x faster and is backwards compatible. Please use @formatjs/icu-messageformat-parser",
+      "dev": true
+    },
+    "node_modules/@scratch/scratch-gui/node_modules/lodash.omit": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.omit/-/lodash.omit-4.5.0.tgz",
+      "integrity": "sha512-XeqSp49hNGmlkj2EJlfrQFIzQ6lXdNro9sddtQzcJY8QaoC2GO0DT7xaIokHeyM+mIT0mPMlPvkYzg2xCuHdZg==",
+      "deprecated": "This package is deprecated. Use destructuring assignment syntax instead.",
+      "dev": true
+    },
+    "node_modules/@scratch/scratch-gui/node_modules/matchmediaquery": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/matchmediaquery/-/matchmediaquery-0.3.1.tgz",
+      "integrity": "sha512-Hlk20WQHRIm9EE9luN1kjRjYXAQToHOIAHPJn9buxBwuhfTHoKUcX+lXBbxc85DVQfXYbEQ4HcwQdd128E3qHQ==",
+      "dev": true,
+      "dependencies": {
+        "css-mediaquery": "^0.1.2"
+      }
+    },
+    "node_modules/@scratch/scratch-gui/node_modules/microee": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/microee/-/microee-0.0.6.tgz",
+      "integrity": "sha512-/LdL3jiBWDJ3oQIRLgRhfeCZNE3patM1LiwCC124+/HHn10sI/G2OAyiMfTNzH5oYWoZBk0tRZADAUOv+0Wt0A==",
+      "dev": true
+    },
+    "node_modules/@scratch/scratch-gui/node_modules/minilog": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/minilog/-/minilog-3.1.0.tgz",
+      "integrity": "sha512-Xfm4jWjWzSAduvEWtuZX/8TMkxfJlCfH7XvikCZe3ptojYTBq1eoEs3rh9/3LNLOckUP86m+8l8+Iw5NU/pBww==",
+      "dev": true,
+      "dependencies": {
+        "microee": "0.0.6"
+      }
+    },
+    "node_modules/@scratch/scratch-gui/node_modules/picocolors": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-0.2.1.tgz",
+      "integrity": "sha512-cMlDqaLEqfSaW8Z7N5Jw+lyIW869EzT73/F5lhtY9cLGoVxSXznfgfXMO0Z5K0o0Q2TkTXq+0KFsdnSe3jDViA==",
+      "dev": true
+    },
+    "node_modules/@scratch/scratch-gui/node_modules/postcss": {
+      "version": "7.0.39",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.39.tgz",
+      "integrity": "sha512-yioayjNbHn6z1/Bywyb2Y4s3yvDAeXGOyxqD+LnVOinq6Mdmd++SW2wUNVzavyyHxd6+DxzWGIuosg6P1Rj8uA==",
+      "dev": true,
+      "dependencies": {
+        "picocolors": "^0.2.1",
+        "source-map": "^0.6.1"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/postcss/"
+      }
+    },
+    "node_modules/@scratch/scratch-gui/node_modules/query-string": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/query-string/-/query-string-5.1.1.tgz",
+      "integrity": "sha512-gjWOsm2SoGlgLEdAGt7a6slVOk9mGiXmPFMqrEhLQ68rhQuBnpfs3+EmlvqKyxnCo9/PPlF+9MtY02S1aFg+Jw==",
+      "dev": true,
+      "dependencies": {
+        "decode-uri-component": "^0.2.0",
+        "object-assign": "^4.1.0",
+        "strict-uri-encode": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/@scratch/scratch-gui/node_modules/react-intl": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/react-intl/-/react-intl-2.9.0.tgz",
+      "integrity": "sha512-27jnDlb/d2A7mSJwrbOBnUgD+rPep+abmoJE511Tf8BnoONIAUehy/U1zZCHGO17mnOwMWxqN4qC0nW11cD6rA==",
+      "dev": true,
+      "dependencies": {
+        "hoist-non-react-statics": "^3.3.0",
+        "intl-format-cache": "^2.0.5",
+        "intl-messageformat": "^2.1.0",
+        "intl-relativeformat": "^2.1.0",
+        "invariant": "^2.1.1"
+      },
+      "peerDependencies": {
+        "prop-types": "^15.5.4",
+        "react": "^0.14.9 || ^15.0.0 || ^16.0.0"
+      }
+    },
+    "node_modules/@scratch/scratch-gui/node_modules/react-responsive": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/react-responsive/-/react-responsive-5.0.0.tgz",
+      "integrity": "sha512-oEimZ0FTCC3/pjGDEBHOz06nWbBNDIbMGOdRYp6K9SBUmrqgNAX77hTiqvmRQeLyI97zz4F4kiaFRxFspDxE+w==",
+      "dev": true,
+      "dependencies": {
+        "hyphenate-style-name": "^1.0.0",
+        "matchmediaquery": "^0.3.0",
+        "prop-types": "^15.6.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "peerDependencies": {
+        "react": "^16.0.0"
+      }
+    },
+    "node_modules/@scratch/scratch-gui/node_modules/scratch-audio": {
+      "version": "1.0.332",
+      "resolved": "https://registry.npmjs.org/scratch-audio/-/scratch-audio-1.0.332.tgz",
+      "integrity": "sha512-ok9gw14R4KmYXNtJ2qrSI3PKRksTH+ROfoe8tyZTkumr+8+Coam2/inuH4aVJygRda5X7xFrERstlkZ8X8zeTQ==",
+      "dev": true,
+      "dependencies": {
+        "audio-context": "^1.0.1",
+        "minilog": "^3.0.1",
+        "startaudiocontext": "^1.2.1"
+      }
+    },
+    "node_modules/@scratch/scratch-gui/node_modules/scratch-l10n": {
+      "version": "3.18.357",
+      "resolved": "https://registry.npmjs.org/scratch-l10n/-/scratch-l10n-3.18.357.tgz",
+      "integrity": "sha512-Rs3YmUa2dzpYqT1O/YT15g99sIwnC7j9TOOmOhUphVKLeiYUvJWiRPKZCugA7/hbIMYZV5VLkmuDgGXhgfSOBw==",
+      "dev": true,
+      "dependencies": {
+        "@transifex/api": "4.3.0",
+        "download": "8.0.0",
+        "transifex": "1.6.6"
+      },
+      "bin": {
+        "build-i18n-src": "scripts/build-i18n-src.js",
+        "tx-push-src": "scripts/tx-push-src.js"
+      }
+    },
+    "node_modules/@scratch/scratch-gui/node_modules/scratch-paint": {
+      "version": "2.2.518",
+      "resolved": "https://registry.npmjs.org/scratch-paint/-/scratch-paint-2.2.518.tgz",
+      "integrity": "sha512-cyxSMgLLC3z6wMpHcc0HpK2yyj5AcDhiUbee03Ml1/UbbmQA9kbe+itT9QMk2mNCW9KNWL9G/BkOLDhaLCwESg==",
+      "dev": true,
+      "dependencies": {
+        "@scratch/paper": "^0.11.20221201200345",
+        "classnames": "^2.2.5",
+        "keymirror": "^0.1.1",
+        "lodash.bindall": "^4.4.0",
+        "lodash.omit": "^4.5.0",
+        "minilog": "^3.1.0",
+        "parse-color": "^1.0.0",
+        "prop-types": "^15.5.10"
+      },
+      "peerDependencies": {
+        "react": "^16",
+        "react-dom": "^16",
+        "react-intl": "^2",
+        "react-intl-redux": "^0.7 || ^2.0.0",
+        "react-popover": "^0.5",
+        "react-redux": "^5",
+        "react-responsive": "^5",
+        "react-style-proptype": "^3",
+        "react-tooltip": "^4",
+        "redux": "^3",
+        "scratch-render-fonts": "^1.0.0"
+      }
+    },
+    "node_modules/@scratch/scratch-render": {
+      "version": "11.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/@scratch/scratch-render/-/scratch-render-11.0.0-beta.2.tgz",
+      "integrity": "sha512-1Vzcq8JKsIIfJ1X3n6e41VP09KGN+/8oDPVbZAYsZ76QiS5b0tF/C7RxJnK+/um34/de9FUiKP8lw3rpMG5YhA==",
+      "dev": true,
+      "dependencies": {
+        "@scratch/scratch-svg-renderer": "11.0.0-beta.2",
+        "grapheme-breaker": "^0.3.2",
+        "hull.js": "0.2.10",
+        "ify-loader": "^1.0.4",
+        "linebreak": "^0.3.0",
+        "minilog": "^3.1.0",
+        "raw-loader": "^0.5.1",
+        "twgl.js": "^4.4.0"
+      },
+      "peerDependencies": {
+        "scratch-render-fonts": "^1.0.0"
+      }
+    },
+    "node_modules/@scratch/scratch-render/node_modules/microee": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/microee/-/microee-0.0.6.tgz",
+      "integrity": "sha512-/LdL3jiBWDJ3oQIRLgRhfeCZNE3patM1LiwCC124+/HHn10sI/G2OAyiMfTNzH5oYWoZBk0tRZADAUOv+0Wt0A==",
+      "dev": true
+    },
+    "node_modules/@scratch/scratch-render/node_modules/minilog": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/minilog/-/minilog-3.1.0.tgz",
+      "integrity": "sha512-Xfm4jWjWzSAduvEWtuZX/8TMkxfJlCfH7XvikCZe3ptojYTBq1eoEs3rh9/3LNLOckUP86m+8l8+Iw5NU/pBww==",
+      "dev": true,
+      "dependencies": {
+        "microee": "0.0.6"
+      }
+    },
+    "node_modules/@scratch/scratch-render/node_modules/raw-loader": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/raw-loader/-/raw-loader-0.5.1.tgz",
+      "integrity": "sha512-sf7oGoLuaYAScB4VGr0tzetsYlS8EJH6qnTCfQ/WVEa89hALQ4RQfCKt5xCyPQKPDUbVUAIP1QsxAwfAjlDp7Q==",
+      "dev": true
+    },
+    "node_modules/@scratch/scratch-svg-renderer": {
+      "version": "11.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/@scratch/scratch-svg-renderer/-/scratch-svg-renderer-11.0.0-beta.2.tgz",
+      "integrity": "sha512-GC2I6tBmTyMsirSG8fdiXKsVHOQIZ/hGgrgQcbk3E7sIThNIODhx3YDuKqZEKQM+3OqOG3CCqD5/X8kEy2711g==",
+      "dev": true,
+      "dependencies": {
+        "base64-js": "^1.2.1",
+        "base64-loader": "^1.0.0",
+        "css-tree": "^1.1.3",
+        "fastestsmallesttextencoderdecoder": "^1.0.22",
+        "isomorphic-dompurify": "^2.4.0",
+        "minilog": "^3.1.0",
+        "transformation-matrix": "^1.15.0"
+      },
+      "peerDependencies": {
+        "scratch-render-fonts": "^1.0.0"
+      }
+    },
+    "node_modules/@scratch/scratch-svg-renderer/node_modules/microee": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/microee/-/microee-0.0.6.tgz",
+      "integrity": "sha512-/LdL3jiBWDJ3oQIRLgRhfeCZNE3patM1LiwCC124+/HHn10sI/G2OAyiMfTNzH5oYWoZBk0tRZADAUOv+0Wt0A==",
+      "dev": true
+    },
+    "node_modules/@scratch/scratch-svg-renderer/node_modules/minilog": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/minilog/-/minilog-3.1.0.tgz",
+      "integrity": "sha512-Xfm4jWjWzSAduvEWtuZX/8TMkxfJlCfH7XvikCZe3ptojYTBq1eoEs3rh9/3LNLOckUP86m+8l8+Iw5NU/pBww==",
+      "dev": true,
+      "dependencies": {
+        "microee": "0.0.6"
+      }
+    },
+    "node_modules/@scratch/scratch-vm": {
+      "version": "11.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/@scratch/scratch-vm/-/scratch-vm-11.0.0-beta.2.tgz",
+      "integrity": "sha512-j4TpOlwXrrPaASMLYQ0Vq3IE6aq+Y294YUQ9VHR4QlRLp55BxHI5zymawwi0NwPQKEv7bsxbqumKl23v7kU+yA==",
+      "dev": true,
+      "dependencies": {
+        "@scratch/scratch-render": "11.0.0-beta.2",
+        "@scratch/scratch-svg-renderer": "11.0.0-beta.2",
+        "@vernier/godirect": "^1.5.0",
+        "arraybuffer-loader": "^1.0.6",
+        "atob": "^2.1.2",
+        "btoa": "^1.2.1",
+        "canvas-toBlob": "^1.0.0",
+        "decode-html": "^2.0.0",
+        "diff-match-patch": "^1.0.4",
+        "format-message": "^6.2.1",
+        "htmlparser2": "^3.10.0",
+        "immutable": "^3.8.1",
+        "jszip": "^3.1.5",
+        "minilog": "^3.1.0",
+        "scratch-audio": "^1.0.6",
+        "scratch-parser": "^5.1.1",
+        "scratch-sb1-converter": "^1.0.0",
+        "scratch-storage": "^4.0.24",
+        "scratch-translate-extension-languages": "^1.0.0",
+        "text-encoding": "^0.7.0",
+        "uuid": "^8.3.2",
+        "web-worker": "^1.3.0"
+      }
+    },
+    "node_modules/@scratch/scratch-vm/node_modules/immutable": {
+      "version": "3.8.2",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-3.8.2.tgz",
+      "integrity": "sha512-15gZoQ38eYjEjxkorfbcgBKBL6R7T459OuK+CpcWt7O3KF4uPCx2tD0uFETlUDIyo+1789crbMhTvQBSR5yBMg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/@scratch/scratch-vm/node_modules/microee": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/microee/-/microee-0.0.6.tgz",
+      "integrity": "sha512-/LdL3jiBWDJ3oQIRLgRhfeCZNE3patM1LiwCC124+/HHn10sI/G2OAyiMfTNzH5oYWoZBk0tRZADAUOv+0Wt0A==",
+      "dev": true
+    },
+    "node_modules/@scratch/scratch-vm/node_modules/minilog": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/minilog/-/minilog-3.1.0.tgz",
+      "integrity": "sha512-Xfm4jWjWzSAduvEWtuZX/8TMkxfJlCfH7XvikCZe3ptojYTBq1eoEs3rh9/3LNLOckUP86m+8l8+Iw5NU/pBww==",
+      "dev": true,
+      "dependencies": {
+        "microee": "0.0.6"
+      }
+    },
+    "node_modules/@scratch/scratch-vm/node_modules/scratch-audio": {
+      "version": "1.0.332",
+      "resolved": "https://registry.npmjs.org/scratch-audio/-/scratch-audio-1.0.332.tgz",
+      "integrity": "sha512-ok9gw14R4KmYXNtJ2qrSI3PKRksTH+ROfoe8tyZTkumr+8+Coam2/inuH4aVJygRda5X7xFrERstlkZ8X8zeTQ==",
+      "dev": true,
+      "dependencies": {
+        "audio-context": "^1.0.1",
+        "minilog": "^3.0.1",
+        "startaudiocontext": "^1.2.1"
+      }
+    },
+    "node_modules/@scratch/scratch-vm/node_modules/scratch-parser": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/scratch-parser/-/scratch-parser-5.2.1.tgz",
+      "integrity": "sha512-O9acef/B5MAQSB6PrEGKtbmEL1AOVZf4mYZnR0sNlzRvqqaEd+fZDL5SM7E9uQP09dIghefrm6/xmgzQIJP9Wg==",
+      "dev": true,
+      "dependencies": {
+        "ajv": "^6.3.0",
+        "jszip": "^3.1.5",
+        "pify": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/@scratch/scratch-vm/node_modules/scratch-sb1-converter": {
+      "version": "1.0.324",
+      "resolved": "https://registry.npmjs.org/scratch-sb1-converter/-/scratch-sb1-converter-1.0.324.tgz",
+      "integrity": "sha512-ZHIf2KCmYKchayLQFknni7QfXhOCI+w4Wq1wIQuN5D6xZwUyIe51/B4YO+pofOGr3tz4nnwQIjgs3AowdNKWDQ==",
+      "dev": true,
+      "dependencies": {
+        "js-md5": "^0.7.3",
+        "minilog": "^3.1.0",
+        "text-encoding": "^0.7.0"
+      }
+    },
     "node_modules/@sinclair/typebox": {
       "version": "0.27.8",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
@@ -4882,6 +5351,7 @@
       "version": "3.5.2",
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
       "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
+      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "ajv": "^6.9.1"
@@ -6349,7 +6819,6 @@
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
       "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -7736,10 +8205,9 @@
       }
     },
     "node_modules/cross-fetch": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.2.0.tgz",
-      "integrity": "sha512-Q+xVJLoGOeIMXZmbUK4HYk+69cQH6LudR0Vu/pRm2YlU/hDV9CiS0gKUMaWY5f2NeUH9C1nV3bsTlCo0FsTV1Q==",
-      "license": "MIT",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-4.1.0.tgz",
+      "integrity": "sha512-uKm5PU+MHTootlWEY+mZ4vvXoCn4fLQxT9dSc1sXVMSFkINTJVN8cAQROpwcKm8bJ/c7rgZVIBWzH5T78sNZZw==",
       "dependencies": {
         "node-fetch": "^2.7.0"
       }
@@ -13407,7 +13875,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
       "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -22330,35 +22797,6 @@
         "url": "https://opencollective.com/webpack"
       }
     },
-    "node_modules/scratch-audio": {
-      "version": "2.0.55",
-      "resolved": "https://registry.npmjs.org/scratch-audio/-/scratch-audio-2.0.55.tgz",
-      "integrity": "sha512-0I/GlZ/iLZ+/DoC5oVL3QPkYZcoh2mZmuylEDSCgo1Ze4a361pz9d1tHB3soCbHiv5KwlvP+dWvNWXFCxh7UTA==",
-      "dev": true,
-      "license": "AGPL-3.0-only",
-      "dependencies": {
-        "audio-context": "^1.0.1",
-        "minilog": "^3.0.1",
-        "startaudiocontext": "^1.2.1"
-      }
-    },
-    "node_modules/scratch-audio/node_modules/microee": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/microee/-/microee-0.0.6.tgz",
-      "integrity": "sha512-/LdL3jiBWDJ3oQIRLgRhfeCZNE3patM1LiwCC124+/HHn10sI/G2OAyiMfTNzH5oYWoZBk0tRZADAUOv+0Wt0A==",
-      "dev": true,
-      "license": "BSD"
-    },
-    "node_modules/scratch-audio/node_modules/minilog": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/minilog/-/minilog-3.1.0.tgz",
-      "integrity": "sha512-Xfm4jWjWzSAduvEWtuZX/8TMkxfJlCfH7XvikCZe3ptojYTBq1eoEs3rh9/3LNLOckUP86m+8l8+Iw5NU/pBww==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "microee": "0.0.6"
-      }
-    },
     "node_modules/scratch-blocks": {
       "version": "1.1.206",
       "resolved": "https://registry.npmjs.org/scratch-blocks/-/scratch-blocks-1.1.206.tgz",
@@ -22454,301 +22892,6 @@
         "tx-push-src": "scripts/tx-push-src.js"
       }
     },
-    "node_modules/scratch-gui": {
-      "version": "5.1.33",
-      "resolved": "https://registry.npmjs.org/scratch-gui/-/scratch-gui-5.1.33.tgz",
-      "integrity": "sha512-Qzvciv7paSgctvKdXpuCWsGyQyZNoskWK/OPORW7jDSPCLrOTuqcUTa4F/e8kqu0bUp2JolA0IQUMZB0glpM8w==",
-      "dev": true,
-      "license": "AGPL-3.0-only",
-      "dependencies": {
-        "@microbit/microbit-universal-hex": "^0.2.2",
-        "arraybuffer-loader": "^1.0.6",
-        "autoprefixer": "^9.0.1",
-        "balance-text": "^3.3.1",
-        "base64-loader": "^1.0.0",
-        "bowser": "^1.9.4",
-        "cat-blocks": "npm:scratch-blocks@0.1.0-prerelease.20220318143026",
-        "classnames": "^2.2.6",
-        "computed-style-to-inline-style": "^3.0.0",
-        "cookie": "^0.6.0",
-        "copy-webpack-plugin": "^6.4.1",
-        "core-js": "^2.5.7",
-        "css-loader": "5.2.7",
-        "dapjs": "^2.3.0",
-        "es6-object-assign": "^1.1.0",
-        "fastestsmallesttextencoderdecoder": "^1.0.22",
-        "get-float-time-domain-data": "^0.1.0",
-        "get-user-media-promise": "^1.1.4",
-        "immutable": "^3.8.2",
-        "intl": "^1.2.5",
-        "js-base64": "^2.4.9",
-        "keymirror": "^0.1.1",
-        "lodash.bindall": "^4.4.0",
-        "lodash.debounce": "^4.0.8",
-        "lodash.defaultsdeep": "^4.6.1",
-        "lodash.omit": "^4.5.0",
-        "lodash.throttle": "^4.0.1",
-        "minilog": "^3.1.0",
-        "omggif": "^1.0.9",
-        "papaparse": "^5.3.0",
-        "postcss-import": "^12.0.0",
-        "postcss-loader": "4.3.0",
-        "postcss-simple-vars": "^5.0.1",
-        "prop-types": "^15.5.10",
-        "query-string": "^5.1.1",
-        "raw-loader": "^4.0.0",
-        "react-contextmenu": "^2.9.4",
-        "react-draggable": "^3.0.5",
-        "react-ga": "^2.5.3",
-        "react-intl": "^2.9.0",
-        "react-modal": "^3.9.1",
-        "react-popover": "^0.5.10",
-        "react-redux": "^5.0.7",
-        "react-responsive": "^5.0.0",
-        "react-style-proptype": "^3.2.2",
-        "react-tabs": "^2.3.0",
-        "react-tooltip": "^4.5.1",
-        "react-virtualized": "^9.20.1",
-        "redux": "^3.7.2",
-        "redux-throttle": "^0.1.1",
-        "scratch-audio": "^2.0.0",
-        "scratch-blocks": "^1.1.6",
-        "scratch-l10n": "^5.0.0",
-        "scratch-paint": "^3.0.0",
-        "scratch-render": "^2.0.0",
-        "scratch-render-fonts": "^1.0.2",
-        "scratch-storage": "^4.0.0",
-        "scratch-svg-renderer": "^3.0.0",
-        "scratch-vm": "^5.0.0",
-        "startaudiocontext": "^1.2.1",
-        "style-loader": "4.0.0",
-        "to-style": "^1.3.3",
-        "wav-encoder": "^1.3.0",
-        "xhr": "^2.5.0"
-      },
-      "peerDependencies": {
-        "react": "^16.0.0",
-        "react-dom": "^16.0.0"
-      }
-    },
-    "node_modules/scratch-gui/node_modules/autoprefixer": {
-      "version": "9.8.8",
-      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-9.8.8.tgz",
-      "integrity": "sha512-eM9d/swFopRt5gdJ7jrpCwgvEMIayITpojhkkSMRsFHYuH5bkSQ4p/9qTEHtmNudUZh22Tehu7I6CxAW0IXTKA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "browserslist": "^4.12.0",
-        "caniuse-lite": "^1.0.30001109",
-        "normalize-range": "^0.1.2",
-        "num2fraction": "^1.2.2",
-        "picocolors": "^0.2.1",
-        "postcss": "^7.0.32",
-        "postcss-value-parser": "^4.1.0"
-      },
-      "bin": {
-        "autoprefixer": "bin/autoprefixer"
-      },
-      "funding": {
-        "type": "tidelift",
-        "url": "https://tidelift.com/funding/github/npm/autoprefixer"
-      }
-    },
-    "node_modules/scratch-gui/node_modules/cookie": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.6.0.tgz",
-      "integrity": "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/scratch-gui/node_modules/core-js": {
-      "version": "2.6.12",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
-      "integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==",
-      "deprecated": "core-js@<3.23.3 is no longer maintained and not recommended for usage due to the number of issues. Because of the V8 engine whims, feature detection in old core-js versions could cause a slowdown up to 100x even if nothing is polyfilled. Some versions have web compatibility issues. Please, upgrade your dependencies to the actual version of core-js.",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT"
-    },
-    "node_modules/scratch-gui/node_modules/cross-fetch": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-4.1.0.tgz",
-      "integrity": "sha512-uKm5PU+MHTootlWEY+mZ4vvXoCn4fLQxT9dSc1sXVMSFkINTJVN8cAQROpwcKm8bJ/c7rgZVIBWzH5T78sNZZw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "node-fetch": "^2.7.0"
-      }
-    },
-    "node_modules/scratch-gui/node_modules/decode-uri-component": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.2.tgz",
-      "integrity": "sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10"
-      }
-    },
-    "node_modules/scratch-gui/node_modules/immutable": {
-      "version": "3.8.2",
-      "resolved": "https://registry.npmjs.org/immutable/-/immutable-3.8.2.tgz",
-      "integrity": "sha512-15gZoQ38eYjEjxkorfbcgBKBL6R7T459OuK+CpcWt7O3KF4uPCx2tD0uFETlUDIyo+1789crbMhTvQBSR5yBMg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/scratch-gui/node_modules/intl-messageformat": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-2.2.0.tgz",
-      "integrity": "sha512-I+tSvHnXqJYjDfNmY95tpFMj30yoakC6OXAo+wu/wTMy6tA/4Fd4mvV7Uzs4cqK/Ap29sHhwjcY+78a8eifcXw==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "intl-messageformat-parser": "1.4.0"
-      }
-    },
-    "node_modules/scratch-gui/node_modules/intl-messageformat-parser": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/intl-messageformat-parser/-/intl-messageformat-parser-1.4.0.tgz",
-      "integrity": "sha512-/XkqFHKezO6UcF4Av2/Lzfrez18R0jyw7kRFhSeB/YRakdrgSc9QfFZUwNJI9swMwMoNPygK1ArC5wdFSjPw+A==",
-      "deprecated": "We've written a new parser that's 6x faster and is backwards compatible. Please use @formatjs/icu-messageformat-parser",
-      "dev": true,
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/scratch-gui/node_modules/lodash.omit": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.omit/-/lodash.omit-4.5.0.tgz",
-      "integrity": "sha512-XeqSp49hNGmlkj2EJlfrQFIzQ6lXdNro9sddtQzcJY8QaoC2GO0DT7xaIokHeyM+mIT0mPMlPvkYzg2xCuHdZg==",
-      "deprecated": "This package is deprecated. Use destructuring assignment syntax instead.",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/scratch-gui/node_modules/matchmediaquery": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/matchmediaquery/-/matchmediaquery-0.3.1.tgz",
-      "integrity": "sha512-Hlk20WQHRIm9EE9luN1kjRjYXAQToHOIAHPJn9buxBwuhfTHoKUcX+lXBbxc85DVQfXYbEQ4HcwQdd128E3qHQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "css-mediaquery": "^0.1.2"
-      }
-    },
-    "node_modules/scratch-gui/node_modules/microee": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/microee/-/microee-0.0.6.tgz",
-      "integrity": "sha512-/LdL3jiBWDJ3oQIRLgRhfeCZNE3patM1LiwCC124+/HHn10sI/G2OAyiMfTNzH5oYWoZBk0tRZADAUOv+0Wt0A==",
-      "dev": true,
-      "license": "BSD"
-    },
-    "node_modules/scratch-gui/node_modules/minilog": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/minilog/-/minilog-3.1.0.tgz",
-      "integrity": "sha512-Xfm4jWjWzSAduvEWtuZX/8TMkxfJlCfH7XvikCZe3ptojYTBq1eoEs3rh9/3LNLOckUP86m+8l8+Iw5NU/pBww==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "microee": "0.0.6"
-      }
-    },
-    "node_modules/scratch-gui/node_modules/picocolors": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-0.2.1.tgz",
-      "integrity": "sha512-cMlDqaLEqfSaW8Z7N5Jw+lyIW869EzT73/F5lhtY9cLGoVxSXznfgfXMO0Z5K0o0Q2TkTXq+0KFsdnSe3jDViA==",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/scratch-gui/node_modules/postcss": {
-      "version": "7.0.39",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.39.tgz",
-      "integrity": "sha512-yioayjNbHn6z1/Bywyb2Y4s3yvDAeXGOyxqD+LnVOinq6Mdmd++SW2wUNVzavyyHxd6+DxzWGIuosg6P1Rj8uA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "picocolors": "^0.2.1",
-        "source-map": "^0.6.1"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/postcss/"
-      }
-    },
-    "node_modules/scratch-gui/node_modules/query-string": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/query-string/-/query-string-5.1.1.tgz",
-      "integrity": "sha512-gjWOsm2SoGlgLEdAGt7a6slVOk9mGiXmPFMqrEhLQ68rhQuBnpfs3+EmlvqKyxnCo9/PPlF+9MtY02S1aFg+Jw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "decode-uri-component": "^0.2.0",
-        "object-assign": "^4.1.0",
-        "strict-uri-encode": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/scratch-gui/node_modules/react-intl": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/react-intl/-/react-intl-2.9.0.tgz",
-      "integrity": "sha512-27jnDlb/d2A7mSJwrbOBnUgD+rPep+abmoJE511Tf8BnoONIAUehy/U1zZCHGO17mnOwMWxqN4qC0nW11cD6rA==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "hoist-non-react-statics": "^3.3.0",
-        "intl-format-cache": "^2.0.5",
-        "intl-messageformat": "^2.1.0",
-        "intl-relativeformat": "^2.1.0",
-        "invariant": "^2.1.1"
-      },
-      "peerDependencies": {
-        "prop-types": "^15.5.4",
-        "react": "^0.14.9 || ^15.0.0 || ^16.0.0"
-      }
-    },
-    "node_modules/scratch-gui/node_modules/react-responsive": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/react-responsive/-/react-responsive-5.0.0.tgz",
-      "integrity": "sha512-oEimZ0FTCC3/pjGDEBHOz06nWbBNDIbMGOdRYp6K9SBUmrqgNAX77hTiqvmRQeLyI97zz4F4kiaFRxFspDxE+w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "hyphenate-style-name": "^1.0.0",
-        "matchmediaquery": "^0.3.0",
-        "prop-types": "^15.6.1"
-      },
-      "engines": {
-        "node": ">= 0.10"
-      },
-      "peerDependencies": {
-        "react": "^16.0.0"
-      }
-    },
-    "node_modules/scratch-gui/node_modules/scratch-storage": {
-      "version": "4.0.39",
-      "resolved": "https://registry.npmjs.org/scratch-storage/-/scratch-storage-4.0.39.tgz",
-      "integrity": "sha512-z5rwHytSn3ag1fnBOOkgg2eNvMSq7sagd96JeB3VOoiiOo5+7zsWUe7sfzyqtWyg5aFRIcfaYq+tRHtK0Y9ntg==",
-      "dev": true,
-      "license": "AGPL-3.0-only",
-      "dependencies": {
-        "@babel/runtime": "^7.21.0",
-        "arraybuffer-loader": "^1.0.3",
-        "base64-js": "^1.3.0",
-        "buffer": "6.0.3",
-        "cross-fetch": "^4.1.0",
-        "fastestsmallesttextencoderdecoder": "^1.0.7",
-        "js-md5": "^0.7.3",
-        "minilog": "^3.1.0"
-      }
-    },
     "node_modules/scratch-l10n": {
       "version": "5.0.101",
       "resolved": "https://registry.npmjs.org/scratch-l10n/-/scratch-l10n-5.0.101.tgz",
@@ -22765,61 +22908,6 @@
         "tx-push-src": "scripts/tx-push-src.js"
       }
     },
-    "node_modules/scratch-paint": {
-      "version": "3.0.111",
-      "resolved": "https://registry.npmjs.org/scratch-paint/-/scratch-paint-3.0.111.tgz",
-      "integrity": "sha512-YRnRqqzqMyqaJy2K0ooBF//PZh5aMc+gf7VGSSia71fY9oYBeZIMb5LGpWc1nsD1s1uNKU+YAascrMuiwqn/Dg==",
-      "dev": true,
-      "license": "AGPL-3.0-only",
-      "dependencies": {
-        "@scratch/paper": "^0.11.20221201200345",
-        "classnames": "^2.2.5",
-        "keymirror": "^0.1.1",
-        "lodash.bindall": "^4.4.0",
-        "lodash.omit": "^4.5.0",
-        "minilog": "^3.1.0",
-        "parse-color": "^1.0.0",
-        "prop-types": "^15.5.10"
-      },
-      "peerDependencies": {
-        "react": "^16",
-        "react-dom": "^16",
-        "react-intl": "^2",
-        "react-intl-redux": "^0.7 || ^2.0.0",
-        "react-popover": "^0.5",
-        "react-redux": "^5",
-        "react-responsive": "^5",
-        "react-style-proptype": "^3",
-        "react-tooltip": "^4",
-        "redux": "^3",
-        "scratch-render-fonts": "^1.0.0"
-      }
-    },
-    "node_modules/scratch-paint/node_modules/lodash.omit": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.omit/-/lodash.omit-4.5.0.tgz",
-      "integrity": "sha512-XeqSp49hNGmlkj2EJlfrQFIzQ6lXdNro9sddtQzcJY8QaoC2GO0DT7xaIokHeyM+mIT0mPMlPvkYzg2xCuHdZg==",
-      "deprecated": "This package is deprecated. Use destructuring assignment syntax instead.",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/scratch-paint/node_modules/microee": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/microee/-/microee-0.0.6.tgz",
-      "integrity": "sha512-/LdL3jiBWDJ3oQIRLgRhfeCZNE3patM1LiwCC124+/HHn10sI/G2OAyiMfTNzH5oYWoZBk0tRZADAUOv+0Wt0A==",
-      "dev": true,
-      "license": "BSD"
-    },
-    "node_modules/scratch-paint/node_modules/minilog": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/minilog/-/minilog-3.1.0.tgz",
-      "integrity": "sha512-Xfm4jWjWzSAduvEWtuZX/8TMkxfJlCfH7XvikCZe3ptojYTBq1eoEs3rh9/3LNLOckUP86m+8l8+Iw5NU/pBww==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "microee": "0.0.6"
-      }
-    },
     "node_modules/scratch-parser": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/scratch-parser/-/scratch-parser-6.0.0.tgz",
@@ -22834,26 +22922,6 @@
         "node": ">=8.0"
       }
     },
-    "node_modules/scratch-render": {
-      "version": "2.0.135",
-      "resolved": "https://registry.npmjs.org/scratch-render/-/scratch-render-2.0.135.tgz",
-      "integrity": "sha512-apmk5dRX9HszmsoIY2t6h8fydxlJJHgjyktuNcL4LON+ogYb1CVe0LvAts2Z/WT3ugHDL4wTf5ZAMXtBSAlg2w==",
-      "dev": true,
-      "license": "AGPL-3.0-only",
-      "dependencies": {
-        "grapheme-breaker": "^0.3.2",
-        "hull.js": "0.2.10",
-        "ify-loader": "^1.0.4",
-        "linebreak": "^0.3.0",
-        "minilog": "^3.1.0",
-        "raw-loader": "^0.5.1",
-        "scratch-svg-renderer": "^3.0.0",
-        "twgl.js": "^4.4.0"
-      },
-      "peerDependencies": {
-        "scratch-render-fonts": "^1.0.0"
-      }
-    },
     "node_modules/scratch-render-fonts": {
       "version": "1.0.157",
       "resolved": "https://registry.npmjs.org/scratch-render-fonts/-/scratch-render-fonts-1.0.157.tgz",
@@ -22863,72 +22931,19 @@
         "base64-loader": "^1.0.0"
       }
     },
-    "node_modules/scratch-render/node_modules/microee": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/microee/-/microee-0.0.6.tgz",
-      "integrity": "sha512-/LdL3jiBWDJ3oQIRLgRhfeCZNE3patM1LiwCC124+/HHn10sI/G2OAyiMfTNzH5oYWoZBk0tRZADAUOv+0Wt0A==",
-      "dev": true,
-      "license": "BSD"
-    },
-    "node_modules/scratch-render/node_modules/minilog": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/minilog/-/minilog-3.1.0.tgz",
-      "integrity": "sha512-Xfm4jWjWzSAduvEWtuZX/8TMkxfJlCfH7XvikCZe3ptojYTBq1eoEs3rh9/3LNLOckUP86m+8l8+Iw5NU/pBww==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "microee": "0.0.6"
-      }
-    },
-    "node_modules/scratch-render/node_modules/raw-loader": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/raw-loader/-/raw-loader-0.5.1.tgz",
-      "integrity": "sha512-sf7oGoLuaYAScB4VGr0tzetsYlS8EJH6qnTCfQ/WVEa89hALQ4RQfCKt5xCyPQKPDUbVUAIP1QsxAwfAjlDp7Q==",
-      "dev": true
-    },
-    "node_modules/scratch-sb1-converter": {
-      "version": "2.0.49",
-      "resolved": "https://registry.npmjs.org/scratch-sb1-converter/-/scratch-sb1-converter-2.0.49.tgz",
-      "integrity": "sha512-njRQEkEh9hiEVB62FZAFJRE6iPD/O+dqPCcLAwOga4u10I+RcGRBCCOqmDnWV1m5o9xXNPUw30xQ5HJTfJLVFA==",
-      "dev": true,
-      "license": "AGPL-3.0-only",
-      "dependencies": {
-        "js-md5": "^0.7.3",
-        "minilog": "^3.1.0",
-        "text-encoding": "^0.7.0"
-      }
-    },
-    "node_modules/scratch-sb1-converter/node_modules/microee": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/microee/-/microee-0.0.6.tgz",
-      "integrity": "sha512-/LdL3jiBWDJ3oQIRLgRhfeCZNE3patM1LiwCC124+/HHn10sI/G2OAyiMfTNzH5oYWoZBk0tRZADAUOv+0Wt0A==",
-      "dev": true,
-      "license": "BSD"
-    },
-    "node_modules/scratch-sb1-converter/node_modules/minilog": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/minilog/-/minilog-3.1.0.tgz",
-      "integrity": "sha512-Xfm4jWjWzSAduvEWtuZX/8TMkxfJlCfH7XvikCZe3ptojYTBq1eoEs3rh9/3LNLOckUP86m+8l8+Iw5NU/pBww==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "microee": "0.0.6"
-      }
-    },
     "node_modules/scratch-storage": {
-      "version": "2.3.284",
-      "resolved": "https://registry.npmjs.org/scratch-storage/-/scratch-storage-2.3.284.tgz",
-      "integrity": "sha512-GlMSCQtP3O+Sd8504Q7P19OKB92i5v5k5oHBgaBoYCksxSLK3477Zw6c5wKRPa6314sqrmo/EAGxW3QZeoc9Yw==",
-      "license": "BSD-3-Clause",
+      "version": "4.0.39",
+      "resolved": "https://registry.npmjs.org/scratch-storage/-/scratch-storage-4.0.39.tgz",
+      "integrity": "sha512-z5rwHytSn3ag1fnBOOkgg2eNvMSq7sagd96JeB3VOoiiOo5+7zsWUe7sfzyqtWyg5aFRIcfaYq+tRHtK0Y9ntg==",
       "dependencies": {
         "@babel/runtime": "^7.21.0",
         "arraybuffer-loader": "^1.0.3",
         "base64-js": "^1.3.0",
-        "cross-fetch": "^3.1.5",
+        "buffer": "6.0.3",
+        "cross-fetch": "^4.1.0",
         "fastestsmallesttextencoderdecoder": "^1.0.7",
         "js-md5": "^0.7.3",
-        "minilog": "^3.1.0",
-        "worker-loader": "^2.0.0"
+        "minilog": "^3.1.0"
       }
     },
     "node_modules/scratch-storage/node_modules/microee": {
@@ -22946,134 +22961,12 @@
         "microee": "0.0.6"
       }
     },
-    "node_modules/scratch-svg-renderer": {
-      "version": "3.0.51",
-      "resolved": "https://registry.npmjs.org/scratch-svg-renderer/-/scratch-svg-renderer-3.0.51.tgz",
-      "integrity": "sha512-LPKK+g4MqRZcIPMvwLVzCAicyxsal82QLBWGIo29kXI3AC3gMXbc4DRBSLcb3ji0u5Yi84Co2NCBBR55zEuQ/Q==",
-      "dev": true,
-      "license": "AGPL-3.0-only",
-      "dependencies": {
-        "base64-js": "^1.2.1",
-        "base64-loader": "^1.0.0",
-        "css-tree": "^1.1.3",
-        "fastestsmallesttextencoderdecoder": "^1.0.22",
-        "isomorphic-dompurify": "^2.4.0",
-        "minilog": "^3.1.0",
-        "transformation-matrix": "^1.15.0"
-      },
-      "peerDependencies": {
-        "scratch-render-fonts": "^1.0.0"
-      }
-    },
-    "node_modules/scratch-svg-renderer/node_modules/microee": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/microee/-/microee-0.0.6.tgz",
-      "integrity": "sha512-/LdL3jiBWDJ3oQIRLgRhfeCZNE3patM1LiwCC124+/HHn10sI/G2OAyiMfTNzH5oYWoZBk0tRZADAUOv+0Wt0A==",
-      "dev": true,
-      "license": "BSD"
-    },
-    "node_modules/scratch-svg-renderer/node_modules/minilog": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/minilog/-/minilog-3.1.0.tgz",
-      "integrity": "sha512-Xfm4jWjWzSAduvEWtuZX/8TMkxfJlCfH7XvikCZe3ptojYTBq1eoEs3rh9/3LNLOckUP86m+8l8+Iw5NU/pBww==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "microee": "0.0.6"
-      }
-    },
     "node_modules/scratch-translate-extension-languages": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/scratch-translate-extension-languages/-/scratch-translate-extension-languages-1.0.7.tgz",
       "integrity": "sha512-6+bQU9iVYv23T8J0SjpV6MTugm0y8myh/4DPgu1BGfccysdkaWzu3MkNGQyQRUlbqAiW9wM7ctfv3USPEkzTgg==",
       "dev": true,
       "license": "BSD-3-Clause"
-    },
-    "node_modules/scratch-vm": {
-      "version": "5.0.136",
-      "resolved": "https://registry.npmjs.org/scratch-vm/-/scratch-vm-5.0.136.tgz",
-      "integrity": "sha512-h3IiG+tq31QLficya5Qvf5YZjb8DeBHjAOViCQylypoS7Y2/lEnWkvJJz/IPMJFdscg8aHm2rhTADM58JWvgzg==",
-      "dev": true,
-      "license": "AGPL-3.0-only",
-      "dependencies": {
-        "@vernier/godirect": "^1.5.0",
-        "arraybuffer-loader": "^1.0.6",
-        "atob": "^2.1.2",
-        "btoa": "^1.2.1",
-        "buffer": "^6.0.3",
-        "canvas-toBlob": "^1.0.0",
-        "decode-html": "^2.0.0",
-        "diff-match-patch": "^1.0.4",
-        "format-message": "^6.2.1",
-        "htmlparser2": "^3.10.0",
-        "immutable": "^3.8.1",
-        "jszip": "^3.1.5",
-        "minilog": "^3.1.0",
-        "scratch-audio": "^2.0.0",
-        "scratch-parser": "^6.0.0",
-        "scratch-render": "^2.0.0",
-        "scratch-sb1-converter": "^2.0.0",
-        "scratch-storage": "^4.0.0",
-        "scratch-svg-renderer": "3.0.51",
-        "scratch-translate-extension-languages": "^1.0.0",
-        "text-encoding": "^0.7.0",
-        "uuid": "^8.3.2",
-        "web-worker": "^1.3.0"
-      }
-    },
-    "node_modules/scratch-vm/node_modules/cross-fetch": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-4.1.0.tgz",
-      "integrity": "sha512-uKm5PU+MHTootlWEY+mZ4vvXoCn4fLQxT9dSc1sXVMSFkINTJVN8cAQROpwcKm8bJ/c7rgZVIBWzH5T78sNZZw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "node-fetch": "^2.7.0"
-      }
-    },
-    "node_modules/scratch-vm/node_modules/immutable": {
-      "version": "3.8.2",
-      "resolved": "https://registry.npmjs.org/immutable/-/immutable-3.8.2.tgz",
-      "integrity": "sha512-15gZoQ38eYjEjxkorfbcgBKBL6R7T459OuK+CpcWt7O3KF4uPCx2tD0uFETlUDIyo+1789crbMhTvQBSR5yBMg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/scratch-vm/node_modules/microee": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/microee/-/microee-0.0.6.tgz",
-      "integrity": "sha512-/LdL3jiBWDJ3oQIRLgRhfeCZNE3patM1LiwCC124+/HHn10sI/G2OAyiMfTNzH5oYWoZBk0tRZADAUOv+0Wt0A==",
-      "dev": true,
-      "license": "BSD"
-    },
-    "node_modules/scratch-vm/node_modules/minilog": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/minilog/-/minilog-3.1.0.tgz",
-      "integrity": "sha512-Xfm4jWjWzSAduvEWtuZX/8TMkxfJlCfH7XvikCZe3ptojYTBq1eoEs3rh9/3LNLOckUP86m+8l8+Iw5NU/pBww==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "microee": "0.0.6"
-      }
-    },
-    "node_modules/scratch-vm/node_modules/scratch-storage": {
-      "version": "4.0.39",
-      "resolved": "https://registry.npmjs.org/scratch-storage/-/scratch-storage-4.0.39.tgz",
-      "integrity": "sha512-z5rwHytSn3ag1fnBOOkgg2eNvMSq7sagd96JeB3VOoiiOo5+7zsWUe7sfzyqtWyg5aFRIcfaYq+tRHtK0Y9ntg==",
-      "dev": true,
-      "license": "AGPL-3.0-only",
-      "dependencies": {
-        "@babel/runtime": "^7.21.0",
-        "arraybuffer-loader": "^1.0.3",
-        "base64-js": "^1.3.0",
-        "buffer": "6.0.3",
-        "cross-fetch": "^4.1.0",
-        "fastestsmallesttextencoderdecoder": "^1.0.7",
-        "js-md5": "^0.7.3",
-        "minilog": "^3.1.0"
-      }
     },
     "node_modules/screenfull": {
       "version": "5.2.0",
@@ -28912,61 +28805,6 @@
       "license": "MIT/X11",
       "engines": {
         "node": ">=0.4.0"
-      }
-    },
-    "node_modules/worker-loader": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/worker-loader/-/worker-loader-2.0.0.tgz",
-      "integrity": "sha512-tnvNp4K3KQOpfRnD20m8xltE3eWh89Ye+5oj7wXEEHKac1P4oZ6p9oTj8/8ExqoSBnk9nu5Pr4nKfQ1hn2APJw==",
-      "license": "MIT",
-      "dependencies": {
-        "loader-utils": "^1.0.0",
-        "schema-utils": "^0.4.0"
-      },
-      "engines": {
-        "node": ">= 6.9.0 || >= 8.9.0"
-      },
-      "peerDependencies": {
-        "webpack": "^3.0.0 || ^4.0.0-alpha.0 || ^4.0.0"
-      }
-    },
-    "node_modules/worker-loader/node_modules/json5": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
-      "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
-      "license": "MIT",
-      "dependencies": {
-        "minimist": "^1.2.0"
-      },
-      "bin": {
-        "json5": "lib/cli.js"
-      }
-    },
-    "node_modules/worker-loader/node_modules/loader-utils": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.2.tgz",
-      "integrity": "sha512-I5d00Pd/jwMD2QCduo657+YM/6L3KZu++pmX9VFncxaxvHcru9jx1lBaFft+r4Mt2jK0Yhp41XlRAihzPxHNCg==",
-      "license": "MIT",
-      "dependencies": {
-        "big.js": "^5.2.2",
-        "emojis-list": "^3.0.0",
-        "json5": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=4.0.0"
-      }
-    },
-    "node_modules/worker-loader/node_modules/schema-utils": {
-      "version": "0.4.7",
-      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-0.4.7.tgz",
-      "integrity": "sha512-v/iwU6wvwGK8HbU9yi3/nhGzP0yGSuhQMzL6ySiec1FSrZZDkhm4noOSWzrNFo/jEc+SJY6jRTwuwbSXJPDUnQ==",
-      "license": "MIT",
-      "dependencies": {
-        "ajv": "^6.1.0",
-        "ajv-keywords": "^3.1.0"
-      },
-      "engines": {
-        "node": ">= 4"
       }
     },
     "node_modules/world-calendars": {

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "react-twitter-embed": "3.0.3",
     "react-use": "17.6.0",
     "scratch-parser": "6.0.0",
-    "scratch-storage": "2.3.284"
+    "scratch-storage": "^4.0.1"
   },
   "devDependencies": {
     "@babel/cli": "7.26.4",
@@ -74,6 +74,7 @@
     "@formatjs/intl-numberformat": "8.15.2",
     "@formatjs/intl-pluralrules": "5.4.2",
     "@formatjs/intl-relativetimeformat": "11.4.9",
+    "@scratch/scratch-gui": "^11.0.0-beta.2",
     "@types/jest": "29.5.14",
     "async": "3.2.6",
     "autoprefixer": "10.4.20",
@@ -146,7 +147,6 @@
     "regenerator-runtime": "0.13.9",
     "sass": "1.83.4",
     "sass-loader": "10.5.2",
-    "scratch-gui": "5.1.33",
     "scratch-l10n": "5.0.101",
     "selenium-webdriver": "4.28.1",
     "slick-carousel": "1.8.1",

--- a/src/lib/storage.js
+++ b/src/lib/storage.js
@@ -1,4 +1,4 @@
-import ScratchStorage from 'scratch-storage';
+import {ScratchStorage} from 'scratch-storage';
 
 const PROJECT_HOST = process.env.PROJECT_HOST || 'https://projects.scratch.mit.edu';
 

--- a/src/views/faq/faq.jsx
+++ b/src/views/faq/faq.jsx
@@ -345,7 +345,7 @@ const Faq = injectIntl(props => (
                         id="faq.sourceCodeBody"
                         values={{
                             guiLink: (
-                                <a href="https://github.com/LLK/scratch-gui">GitHub</a>
+                                <a href="https://github.com/scratchfoundation/scratch-editor/tree/develop/packages/scratch-gui">GitHub</a>
                             ),
                             flashLink: (
                                 <a href="https://github.com/LLK/scratch-flash">

--- a/src/views/preview/embed-view.jsx
+++ b/src/views/preview/embed-view.jsx
@@ -11,7 +11,7 @@ const Meta = require('./meta.jsx');
 
 const previewActions = require('../../redux/preview.js');
 
-const GUI = require('scratch-gui');
+const GUI = require('@scratch/scratch-gui');
 const IntlGUI = injectIntl(GUI.default);
 
 class EmbedView extends React.Component {

--- a/src/views/preview/presentation.jsx
+++ b/src/views/preview/presentation.jsx
@@ -8,7 +8,7 @@ const React = require('react');
 const Formsy = require('formsy-react').default;
 const classNames = require('classnames');
 
-const GUI = require('scratch-gui').default;
+const GUI = require('@scratch/scratch-gui').default;
 const IntlGUI = injectIntl(GUI);
 
 const AdminPanel = require('../../components/adminpanel/adminpanel.jsx');

--- a/src/views/preview/project-view.jsx
+++ b/src/views/preview/project-view.jsx
@@ -34,7 +34,7 @@ const projectCommentActions = require('../../redux/project-comment-actions.js');
 
 const frameless = require('../../lib/frameless');
 
-const GUI = require('scratch-gui');
+const GUI = require('@scratch/scratch-gui');
 const IntlGUI = injectIntl(GUI.default);
 
 const localStorageAvailable = 'localStorage' in window && window.localStorage !== null;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -240,29 +240,25 @@ module.exports = {
                 {from: 'static'},
                 {from: 'intl', to: 'js'},
                 {
-                    from: 'node_modules/scratch-gui/dist/static/blocks-media',
+                    from: 'node_modules/@scratch/scratch-gui/dist/static/blocks-media',
                     to: 'static/blocks-media'
                 },
                 {
-                    from: 'node_modules/scratch-gui/dist/chunks',
-                    to: 'static/chunks'
+                    from: 'node_modules/@scratch/scratch-gui/dist/chunks',
+                    to: 'chunks'
                 },
                 {
-                    from: 'node_modules/scratch-gui/dist/extension-worker.js',
-                    to: 'js'
+                    from: 'node_modules/@scratch/scratch-gui/dist/extension-worker.js'
                 },
                 {
-                    from: 'node_modules/scratch-gui/dist/extension-worker.js.map',
-                    to: 'js'
+                    from: 'node_modules/@scratch/scratch-gui/dist/extension-worker.js.map'
                 },
                 {
-                    from: 'node_modules/scratch-gui/dist/static/assets',
-
-                    // TODO: why do tutorials and extension icons expect these files in `js/`?
-                    to: 'js/static/assets'
+                    from: 'node_modules/@scratch/scratch-gui/dist/static/assets',
+                    to: 'static/assets'
                 },
                 {
-                    from: 'node_modules/scratch-gui/dist/*.hex',
+                    from: 'node_modules/@scratch/scratch-gui/dist/*.hex',
                     to: 'static',
                     flatten: true
                 }


### PR DESCRIPTION
### Resolves:
[UEPR-54](https://scratchfoundation.atlassian.net/browse/UEPR-54)

### Changes:
Install scoped dependency for scratch-gui. Revert to using old paths for assets in webpack configuration


[UEPR-54]: https://scratchfoundation.atlassian.net/browse/UEPR-54?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ