### PR TITLE
fix: [UEPR-150] fix bad response type

### DIFF
--- a/src/views/become-a-scratcher/become-a-scratcher.jsx
+++ b/src/views/become-a-scratcher/become-a-scratcher.jsx
@@ -119,7 +119,8 @@ const BecomeAScratcher = ({user, invitedScratcher, scratcher, sessionStatus}) =>
         api({
             host: '',
             uri: `/users/${user.username}/promote-to-scratcher/`,
-            method: 'GET'
+            method: 'GET',
+            responseType: 'text'
         }, err => {
             if (err) {
                 return setShowPromotionError(true);


### PR DESCRIPTION
### Resolves:

[UEPR-150](https://scratchfoundation.atlassian.net/browse/UEPR-150)

### Changes:
For the endpoint Django returns as response string so the response type of the request header should be text. This was the reason the callback for become a new scratcher to not get executed.


[UEPR-150]: https://scratchfoundation.atlassian.net/browse/UEPR-150?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ