### PR TITLE
fix: project name typo and changed images resolution

### DIFF
--- a/src/views/starter-projects/l10n.json
+++ b/src/views/starter-projects/l10n.json
@@ -15,5 +15,6 @@
   "starterProjects.surpriseMe": "Surprise me",
   "starterProjects.gettingStarted": "Getting Started",
   "starterProjects.newToScratch": "New to Scratch? Try the Getting Started tutorial.",
+  "starterProjects.gettingStartedImageDescription": "An illustrated boy plants his flag on top of a freshly painted mountaintop.",
   "starterProjects.tryIt": "Try it!"
 }

--- a/src/views/starter-projects/starter-projects.json
+++ b/src/views/starter-projects/starter-projects.json
@@ -7,7 +7,7 @@
                 "id": 1105113583,
                 "type": "project",
                 "title": "Dance Party",
-                "image": "https://uploads.scratch.mit.edu/get_image/project/1105113583_144x108.png",
+                "image": "https://uploads.scratch.mit.edu/get_image/project/1105113583_184x136.png",
                 "author": {"username": "Scratchteam"},
                 "href": "https://scratch.mit.edu/projects/1105113583/",
                 "stats": {"loves": 0, "remixes": 0}
@@ -16,7 +16,7 @@
                 "id": 1105114913,
                 "type": "project",
                 "title": "Animate the Crab",
-                "image": "https://uploads.scratch.mit.edu/get_image/project/1105114913_144x108.png",
+                "image": "https://uploads.scratch.mit.edu/get_image/project/1105114913_184x136.png",
                 "author": {"username": "Scratchteam"},
                 "href": "https://scratch.mit.edu/projects/1105114913/",
                 "stats": {"loves": 0, "remixes": 0}
@@ -25,7 +25,7 @@
                 "id": 1105114015,
                 "type": "project",
                 "title": "Walk Cycle",
-                "image": "https://uploads.scratch.mit.edu/get_image/project/1105114015_144x108.png",
+                "image": "https://uploads.scratch.mit.edu/get_image/project/1105114015_184x136.png",
                 "author": {"username": "Scratchteam"},
                 "href": "https://scratch.mit.edu/projects/1105114015/",
                 "stats": {"loves": 0, "remixes": 0}
@@ -34,7 +34,7 @@
                 "id": 1105118803,
                 "type": "project",
                 "title": "Make a Mouse Trail",
-                "image": "https://uploads.scratch.mit.edu/get_image/project/1105118803_144x108.png",
+                "image": "https://uploads.scratch.mit.edu/get_image/project/1105118803_184x136.png",
                 "author": {"username": "Scratchteam"},
                 "href": "https://scratch.mit.edu/projects/1105118803/",
                 "stats": {"loves": 0, "remixes": 0}
@@ -43,7 +43,7 @@
                 "id": 1105114421,
                 "type": "project",
                 "title": "Food Truck Animation",
-                "image": "https://uploads.scratch.mit.edu/get_image/project/1105114421_144x108.png",
+                "image": "https://uploads.scratch.mit.edu/get_image/project/1105114421_184x136.png",
                 "author": {"username": "Scratchteam"},
                 "href": "https://scratch.mit.edu/projects/1105114421/",
                 "stats": {"loves": 0, "remixes": 0}
@@ -58,7 +58,7 @@
                 "id": 1110545496,
                 "type": "project",
                 "title": "Make It Fly",
-                "image": "https://uploads.scratch.mit.edu/get_image/project/1110545496_144x108.png",
+                "image": "https://uploads.scratch.mit.edu/get_image/project/1110545496_184x136.png",
                 "author": {"username": "Scratchteam"},
                 "href": "https://scratch.mit.edu/projects/1110545496/",
                 "stats": {"loves": 0, "remixes": 0}
@@ -67,7 +67,7 @@
                 "id": 10128431,
                 "type": "project",
                 "title": "Maze Starter",
-                "image": "https://uploads.scratch.mit.edu/get_image/project/10128431_144x108.png",
+                "image": "https://uploads.scratch.mit.edu/get_image/project/10128431_184x136.png",
                 "author": {"username": "Scratchteam"},
                 "href": "https://scratch.mit.edu/projects/10128431/",
                 "stats": {"loves": 0, "remixes": 0}
@@ -76,7 +76,7 @@
                 "id": 1105678528,
                 "type": "project",
                 "title": "Dress Up Tera",
-                "image": "https://uploads.scratch.mit.edu/get_image/project/1105678528_144x108.png",
+                "image": "https://uploads.scratch.mit.edu/get_image/project/1105678528_184x136.png",
                 "author": {"username": "Scratchteam"},
                 "href": "https://scratch.mit.edu/projects/1105678528/",
                 "stats": {"loves": 0, "remixes": 0}
@@ -85,7 +85,7 @@
                 "id": 10128515,
                 "type": "project",
                 "title": "Pong Starter",
-                "image": "https://uploads.scratch.mit.edu/get_image/project/10128515_144x108.png",
+                "image": "https://uploads.scratch.mit.edu/get_image/project/10128515_184x136.png",
                 "author": {"username": "Scratchteam"},
                 "href": "https://scratch.mit.edu/projects/10128515/",
                 "stats": {"loves": 0, "remixes": 0}
@@ -94,7 +94,7 @@
                 "id": 10128368,
                 "type": "project",
                 "title": "Hide and Seek",
-                "image": "https://uploads.scratch.mit.edu/get_image/project/10128368_144x108.png",
+                "image": "https://uploads.scratch.mit.edu/get_image/project/10128368_184x136.png",
                 "author": {"username": "Scratchteam"},
                 "href": "https://scratch.mit.edu/projects/10128368/",
                 "stats": {"loves": 0, "remixes": 0}
@@ -109,7 +109,7 @@
                 "id": 1111541829,
                 "type": "project",
                 "title": "Stamp Studio",
-                "image": "https://uploads.scratch.mit.edu/get_image/project/1111541829_144x108.png",
+                "image": "https://uploads.scratch.mit.edu/get_image/project/1111541829_184x136.png",
                 "author": {"username": "Scratchteam"},
                 "href": "https://scratch.mit.edu/projects/1111541829/",
                 "stats": {"loves": 0, "remixes": 0}
@@ -118,7 +118,7 @@
                 "id": 1105131011,
                 "type": "project",
                 "title": "Interactive Parallax",
-                "image": "https://uploads.scratch.mit.edu/get_image/project/1105131011_144x108.png",
+                "image": "https://uploads.scratch.mit.edu/get_image/project/1105131011_184x136.png",
                 "author": {"username": "Scratchteam"},
                 "href": "https://scratch.mit.edu/projects/1105131011/",
                 "stats": {"loves": 0, "remixes": 0}
@@ -127,7 +127,7 @@
                 "id": 1111537402,
                 "type": "project",
                 "title": "Soundflower",
-                "image": "https://uploads.scratch.mit.edu/get_image/project/1111537402_144x108.png",
+                "image": "https://uploads.scratch.mit.edu/get_image/project/1111537402_184x136.png",
                 "author": {"username": "Scratchteam"},
                 "href": "https://scratch.mit.edu/projects/1111537402/",
                 "stats": {"loves": 0, "remixes": 0}
@@ -136,7 +136,7 @@
                 "id": 1106198418,
                 "type": "project",
                 "title": "Make Art Come Alive",
-                "image": "https://uploads.scratch.mit.edu/get_image/project/1106198418_144x108.png",
+                "image": "https://uploads.scratch.mit.edu/get_image/project/1106198418_184x136.png",
                 "author": {"username": "Scratchteam"},
                 "href": "https://scratch.mit.edu/projects/1106198418/",
                 "stats": {"loves": 0, "remixes": 0}
@@ -144,8 +144,8 @@
             {
                 "id": 1105521187,
                 "type": "project",
-                "title": "Spin Artn",
-                "image": "https://uploads.scratch.mit.edu/get_image/project/1105521187_144x108.png",
+                "title": "Spin Art",
+                "image": "https://uploads.scratch.mit.edu/get_image/project/1105521187_184x136.png",
                 "author": {"username": "Scratchteam"},
                 "href": "https://scratch.mit.edu/projects/1105521187/",
                 "stats": {"loves": 0, "remixes": 0}
@@ -160,7 +160,7 @@
                 "id": 11640429,
                 "type": "project",
                 "title": "DJ Scratch Cat",
-                "image": "https://uploads.scratch.mit.edu/get_image/project/11640429_144x108.png",
+                "image": "https://uploads.scratch.mit.edu/get_image/project/11640429_184x136.png",
                 "author": {"username": "Scratchteam"},
                 "href": "https://scratch.mit.edu/projects/11640429/",
                 "stats": {"loves": 0, "remixes": 0}
@@ -169,7 +169,7 @@
                 "id": 1106245381,
                 "type": "project",
                 "title": "Piano",
-                "image": "https://uploads.scratch.mit.edu/get_image/project/1106245381_144x108.png",
+                "image": "https://uploads.scratch.mit.edu/get_image/project/1106245381_184x136.png",
                 "author": {"username": "Scratchteam"},
                 "href": "https://scratch.mit.edu/projects/1106245381/",
                 "stats": {"loves": 0, "remixes": 0}
@@ -178,7 +178,7 @@
                 "id": 1106268602,
                 "type": "project",
                 "title": "Catch the Fish, Increase the Pitch",
-                "image": "https://uploads.scratch.mit.edu/get_image/project/1106268602_144x108.png",
+                "image": "https://uploads.scratch.mit.edu/get_image/project/1106268602_184x136.png",
                 "author": {"username": "Scratchteam"},
                 "href": "https://scratch.mit.edu/projects/1106268602/",
                 "stats": {"loves": 0, "remixes": 0}
@@ -187,7 +187,7 @@
                 "id": 1106259376,
                 "type": "project",
                 "title": "Fur Elise with Music Blocks - My Blocks Example",
-                "image": "https://uploads.scratch.mit.edu/get_image/project/1106259376_144x108.png",
+                "image": "https://uploads.scratch.mit.edu/get_image/project/1106259376_184x136.png",
                 "author": {"username": "Scratchteam"},
                 "href": "https://scratch.mit.edu/projects/1106259376/",
                 "stats": {"loves": 0, "remixes": 0}
@@ -196,7 +196,7 @@
                 "id": 1111562971,
                 "type": "project",
                 "title": "Drum Sequencer",
-                "image": "https://uploads.scratch.mit.edu/get_image/project/1111562971_144x108.png",
+                "image": "https://uploads.scratch.mit.edu/get_image/project/1111562971_184x136.png",
                 "author": {"username": "Scratchteam"},
                 "href": "https://scratch.mit.edu/projects/1111562971/",
                 "stats": {"loves": 0, "remixes": 0}
@@ -211,7 +211,7 @@
                 "id": 1110565816,
                 "type": "project",
                 "title": "Story Starter",
-                "image": "https://uploads.scratch.mit.edu/get_image/project/1110565816_144x108.png",
+                "image": "https://uploads.scratch.mit.edu/get_image/project/1110565816_184x136.png",
                 "author": {"username": "Scratchteam"},
                 "href": "https://scratch.mit.edu/projects/1110565816/",
                 "stats": {"loves": 0, "remixes": 0}
@@ -220,7 +220,7 @@
                 "id": 10014866,
                 "type": "project",
                 "title": "5 Random Facts About Me",
-                "image": "https://uploads.scratch.mit.edu/get_image/project/10014866_144x108.png",
+                "image": "https://uploads.scratch.mit.edu/get_image/project/10014866_184x136.png",
                 "author": {"username": "Scratchteam"},
                 "href": "https://scratch.mit.edu/projects/10014866/",
                 "stats": {"loves": 0, "remixes": 0}
@@ -229,7 +229,7 @@
                 "id": 1110571119,
                 "type": "project",
                 "title": "Fill in the Blanks",
-                "image": "https://uploads.scratch.mit.edu/get_image/project/1110571119_144x108.png",
+                "image": "https://uploads.scratch.mit.edu/get_image/project/1110571119_184x136.png",
                 "author": {"username": "Scratchteam"},
                 "href": "https://scratch.mit.edu/projects/1110571119/",
                 "stats": {"loves": 0, "remixes": 0}
@@ -238,7 +238,7 @@
                 "id": 1105521591,
                 "type": "project",
                 "title": "Stop Motion Animation",
-                "image": "https://uploads.scratch.mit.edu/get_image/project/1105521591_144x108.png",
+                "image": "https://uploads.scratch.mit.edu/get_image/project/1105521591_184x136.png",
                 "author": {"username": "Scratchteam"},
                 "href": "https://scratch.mit.edu/projects/1105521591/",
                 "stats": {"loves": 0, "remixes": 0}
@@ -247,7 +247,7 @@
                 "id": 1107181129 ,
                 "type": "project",
                 "title": "Adventure with Scratch Cat",
-                "image": "https://uploads.scratch.mit.edu/get_image/project/1107181129_144x108.png",
+                "image": "https://uploads.scratch.mit.edu/get_image/project/1107181129_184x136.png",
                 "author": {"username": "Scratchteam"},
                 "href": "https://scratch.mit.edu/projects/1107181129/",
                 "stats": {"loves": 0, "remixes": 0}
@@ -262,7 +262,7 @@
                 "id": 1111567332,
                 "type": "project",
                 "title": "Gravity Example",
-                "image": "https://uploads.scratch.mit.edu/get_image/project/1111567332_144x108.png",
+                "image": "https://uploads.scratch.mit.edu/get_image/project/1111567332_184x136.png",
                 "author": {"username": "Scratchteam"},
                 "href": "https://scratch.mit.edu/projects/1111567332/",
                 "stats": {"loves": 0, "remixes": 0}
@@ -271,7 +271,7 @@
                 "id": 1105532968,
                 "type": "project",
                 "title": "Sound Graph",
-                "image": "https://uploads.scratch.mit.edu/get_image/project/1105532968_144x108.png",
+                "image": "https://uploads.scratch.mit.edu/get_image/project/1105532968_184x136.png",
                 "author": {"username": "Scratchteam"},
                 "href": "https://scratch.mit.edu/projects/1105532968/",
                 "stats": {"loves": 0, "remixes": 0}
@@ -280,7 +280,7 @@
                 "id": 1106220358,
                 "type": "project",
                 "title": "Math Game",
-                "image": "https://uploads.scratch.mit.edu/get_image/project/1106220358_144x108.png",
+                "image": "https://uploads.scratch.mit.edu/get_image/project/1106220358_184x136.png",
                 "author": {"username": "Scratchteam"},
                 "href": "https://scratch.mit.edu/projects/1106220358/",
                 "stats": {"loves": 0, "remixes": 0}
@@ -289,7 +289,7 @@
                 "id": 1106279050,
                 "type": "project",
                 "title": "Simple Circuit Simulation",
-                "image": "https://uploads.scratch.mit.edu/get_image/project/1106279050_144x108.png",
+                "image": "https://uploads.scratch.mit.edu/get_image/project/1106279050_184x136.png",
                 "author": {"username": "Scratchteam"},
                 "href": "https://scratch.mit.edu/projects/1106279050/",
                 "stats": {"loves": 0, "remixes": 0}
@@ -298,7 +298,7 @@
                 "id": 1106739913,
                 "type": "project",
                 "title": "X and Y Coordinates",
-                "image": "https://uploads.scratch.mit.edu/get_image/project/1106739913_144x108.png",
+                "image": "https://uploads.scratch.mit.edu/get_image/project/1106739913_184x136.png",
                 "author": {"username": "Scratchteam"},
                 "href": "https://scratch.mit.edu/projects/1106739913/",
                 "stats": {"loves": 0, "remixes": 0}
@@ -313,7 +313,7 @@
                 "id": 1106234816,
                 "type": "project",
                 "title": "Text to Speech",
-                "image": "https://uploads.scratch.mit.edu/get_image/project/1106234816_144x108.png",
+                "image": "https://uploads.scratch.mit.edu/get_image/project/1106234816_184x136.png",
                 "author": {"username": "Scratchteam"},
                 "href": "https://scratch.mit.edu/projects/1106234816/",
                 "stats": {"loves": 0, "remixes": 0}
@@ -322,7 +322,7 @@
                 "id": 1106765499,
                 "type": "project",
                 "title": "Pen Flower",
-                "image": "https://uploads.scratch.mit.edu/get_image/project/1106765499_144x108.png",
+                "image": "https://uploads.scratch.mit.edu/get_image/project/1106765499_184x136.png",
                 "author": {"username": "Scratchteam"},
                 "href": "https://scratch.mit.edu/projects/1106765499/",
                 "stats": {"loves": 0, "remixes": 0}
@@ -331,7 +331,7 @@
                 "id": 1111576868,
                 "type": "project",
                 "title": "Musical Droplets",
-                "image": "https://uploads.scratch.mit.edu/get_image/project/1111576868_144x108.png",
+                "image": "https://uploads.scratch.mit.edu/get_image/project/1111576868_184x136.png",
                 "author": {"username": "Scratchteam"},
                 "href": "https://scratch.mit.edu/projects/1111576868/",
                 "stats": {"loves": 0, "remixes": 0}
@@ -340,7 +340,7 @@
                 "id": 1110579465,
                 "type": "project",
                 "title": "Translate This!",
-                "image": "https://uploads.scratch.mit.edu/get_image/project/1110579465_144x108.png",
+                "image": "https://uploads.scratch.mit.edu/get_image/project/1110579465_184x136.png",
                 "author": {"username": "Scratchteam"},
                 "href": "https://scratch.mit.edu/projects/1110579465/",
                 "stats": {"loves": 0, "remixes": 0}
@@ -349,7 +349,7 @@
                 "id": 1105110383,
                 "type": "project",
                 "title": "Musical Buttons using Video",
-                "image": "https://uploads.scratch.mit.edu/get_image/project/1105110383_144x108.png",
+                "image": "https://uploads.scratch.mit.edu/get_image/project/1105110383_184x136.png",
                 "author": {"username": "Scratchteam"},
                 "href": "https://scratch.mit.edu/projects/1105110383/",
                 "stats": {"loves": 0, "remixes": 0}
@@ -364,7 +364,7 @@
                 "id": 11806234,
                 "type": "project",
                 "title": "Greeting Card",
-                "image": "https://uploads.scratch.mit.edu/get_image/project/11806234_144x108.png",
+                "image": "https://uploads.scratch.mit.edu/get_image/project/11806234_184x136.png",
                 "author": {"username": "Scratchteam"},
                 "href": "https://scratch.mit.edu/projects/11806234/",
                 "stats": {"loves": 0, "remixes": 0}
@@ -373,7 +373,7 @@
                 "id": 1106806960,
                 "type": "project",
                 "title": "Community Quiz",
-                "image": "https://uploads.scratch.mit.edu/get_image/project/1106806960_144x108.png",
+                "image": "https://uploads.scratch.mit.edu/get_image/project/1106806960_184x136.png",
                 "author": {"username": "Scratchteam"},
                 "href": "https://scratch.mit.edu/projects/1106806960/",
                 "stats": {"loves": 0, "remixes": 0}
@@ -382,7 +382,7 @@
                 "id": 1106823880,
                 "type": "project",
                 "title": "Small Wins Trophy ",
-                "image": "https://uploads.scratch.mit.edu/get_image/project/1106823880_144x108.png",
+                "image": "https://uploads.scratch.mit.edu/get_image/project/1106823880_184x136.png",
                 "author": {"username": "Scratchteam"},
                 "href": "https://scratch.mit.edu/projects/1106823880/",
                 "stats": {"loves": 0, "remixes": 0}
@@ -391,7 +391,7 @@
                 "id": 1110573738,
                 "type": "project",
                 "title": "Random Acts of Kindness",
-                "image": "https://uploads.scratch.mit.edu/get_image/project/1110573738_144x108.png",
+                "image": "https://uploads.scratch.mit.edu/get_image/project/1110573738_184x136.png",
                 "author": {"username": "Scratchteam"},
                 "href": "https://scratch.mit.edu/projects/1110573738/",
                 "stats": {"loves": 0, "remixes": 0}
@@ -400,7 +400,7 @@
                 "id": 1111552152,
                 "type": "project",
                 "title": "Folding a Paper Plane Tutorial",
-                "image": "https://uploads.scratch.mit.edu/get_image/project/1111552152_144x108.png",
+                "image": "https://uploads.scratch.mit.edu/get_image/project/1111552152_184x136.png",
                 "author": {"username": "Scratchteam"},
                 "href": "https://scratch.mit.edu/projects/1111552152/",
                 "stats": {"loves": 0, "remixes": 0}

--- a/src/views/starter-projects/starter-projects.jsx
+++ b/src/views/starter-projects/starter-projects.jsx
@@ -66,7 +66,7 @@ const StarterProjects = () => {
             <section className="getting-started">
                 <img
                     alt={intl.formatMessage({
-                        id: 'ideas.gettingStartedImageDescription'
+                        id: 'starterProjects.gettingStartedImageDescription'
                     })}
                     src="/images/ideas/getting-started-illustration.svg"
                 />

--- a/src/views/starter-projects/starter-projects.scss
+++ b/src/views/starter-projects/starter-projects.scss
@@ -191,7 +191,7 @@ $base-bg: $ui-white;
         .think-big,
         .how-to,
         .project-sections .project-section {
-            max-width: 28.75rem;
+            max-width: 22.5rem;
         }
 
         .getting-started .info {


### PR DESCRIPTION
### Changes:

Fixes typo in project name and changes sizes of images to be clearer
Before:
![image](https://github.com/user-attachments/assets/a0dcd3d2-bf26-44da-8152-f2a72f7ce96c)

After:
![image](https://github.com/user-attachments/assets/c6081461-3685-4318-8bd6-c8f082ec2816)
![image](https://github.com/user-attachments/assets/0469e3ed-011b-464d-b92d-34d8cee25d38)
