### PR TITLE
CI/CD improvements: repeatable deploy, auto-deploy prepared releases

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -36,6 +36,11 @@ jobs:
           ) ||
           ''
         }}
+    steps:
+      # apparently you're not allowed to have a job with no steps
+      - name: Report environment
+        run: |
+          echo "Environment: ${{ env.GH_ENVIRONMENT }}"
     outputs:
       environment: ${{ env.GH_ENVIRONMENT }}
       should_deploy: ${{ (env.GH_ENVIRONMENT || '') != '' }}

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -61,6 +61,7 @@ jobs:
         run: |
           cat <<EOF
           Scratch environment: ${SCRATCH_ENV}
+          Should deploy: ${SCRATCH_SHOULD_DEPLOY}
           Node version: $(node --version)
           NPM version: $(npm --version)
           github.workflow: ${{ github.workflow }}

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -104,22 +104,21 @@ jobs:
           npm run test:unit:tap -- --output-file ./test/results/unit-raw.tap
           npm run test:unit:convertReportToXunit
       - name: compress artifacts
-        if: ${{ needs.set-environment.outputs.should_deploy }}
+        if: ${{ needs.set-environment.outputs.should_deploy == 'true' }}
         env:
           ZSTD_NBTHREADS: 0 # tell zstd to automatically choose thread count
         run: |
           mkdir -p artifacts/
           tar -cavf artifacts/build.tar.zst build
       - name: "upload artifact: build"
-        if: ${{ needs.set-environment.outputs.should_deploy }}
+        if: ${{ needs.set-environment.outputs.should_deploy == 'true' }}
         uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4
         with:
           name: build
           path: artifacts/build.tar.zst
           compression-level: 0 # don't re-compress compressed data
-      - name: debug node_modules cache key
-        run: md5sum .nvmrc package-lock.json
       - name: save node_modules for other jobs
+        if: ${{ needs.set-environment.outputs.should_deploy == 'true' }}
         uses: actions/cache/save@v4
         with:
           path: node_modules
@@ -128,14 +127,12 @@ jobs:
     runs-on: ubuntu-latest
     needs: [set-environment, build]
     environment: ${{ needs.set-environment.outputs.environment }}
-    # if: ${{ needs.set-environment.outputs.should_deploy == 'true' }}
+    if: ${{ needs.set-environment.outputs.should_deploy == 'true' }}
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
       - uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4
         with:
           node-version-file: '.nvmrc'
-      - name: debug node_modules cache key
-        run: md5sum .nvmrc package-lock.json
       - name: retrieve node_modules
         uses: actions/cache/restore@v4
         with:
@@ -181,7 +178,8 @@ jobs:
     needs: [set-environment, deploy]
     environment: ${{ needs.set-environment.outputs.environment }}
     # GHA can't reach staging
-    # TODO: run integration tests against localhost?
+    # TODO: Run integration tests against localhost? Not only would that let us test any and all branches,
+    # but we could also, I dunno, consider fully testing _before_ we deploy? :sweat_smile:
     if: ${{ needs.set-environment.outputs.environment == 'production' }}
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -107,12 +107,20 @@ jobs:
           mkdir -p artifacts/
           tar -cavf artifacts/build.tar.zst build
           tar -cavf artifacts/node_modules.tar.zst node_modules
-      - name: upload artifacts
+      - name: "upload artifact: build"
         if: ${{ needs.set-environment.outputs.should_deploy }}
         uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4
         with:
-          path: artifacts/
-          compression-level: 0 # don't re-compress the already compressed artifacts
+          name: build
+          path: artifacts/build.tar.zst
+          compression-level: 0 # don't re-compress compressed data
+      - name: "upload artifact: node_modules"
+        if: ${{ needs.set-environment.outputs.should_deploy }}
+        uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4
+        with:
+          name: node_modules
+          path: artifacts/node_modules.tar.zst
+          compression-level: 0 # don't re-compress compressed data
   deploy:
     runs-on: ubuntu-latest
     needs: [set-environment, build]
@@ -134,6 +142,9 @@ jobs:
         with:
           # if `name` is not specified, it will download all artifacts
           path: artifacts/
+          # upload-artifact makes a ZIP file with the provided `name` (default: `artifact`)
+          # by default, download-artifact will extract that ZIP file into a subdirectory with the same name
+          merge-multiple: true # don't make a subdirectory for each artifact name
       - name: extract artifacts
         env:
           ZSTD_NBTHREADS: 0 # tell zstd to automatically choose thread count
@@ -172,6 +183,9 @@ jobs:
         with:
           # if `name` is not specified, it will download all artifacts
           path: artifacts/
+          # upload-artifact makes a ZIP file with the provided `name` (default: `artifact`)
+          # by default, download-artifact will extract that ZIP file into a subdirectory with the same name
+          merge-multiple: true # don't make a subdirectory for each artifact name
       - name: extract artifacts
         env:
           ZSTD_NBTHREADS: 0 # tell zstd to automatically choose thread count

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -101,11 +101,12 @@ jobs:
           npm run test:unit:convertReportToXunit
       - name: compress artifacts
         if: ${{ needs.set-environment.outputs.should_deploy }}
+        env:
+          ZSTD_NBTHREADS: 0 # tell zstd to automatically choose thread count
         run: |
           mkdir -p artifacts/
-          tar -cavf artifacts/build.tar.zst build &
-          tar -cavf artifacts/node_modules.tar.zst node_modules &
-          wait
+          tar -cavf artifacts/build.tar.zst build
+          tar -cavf artifacts/node_modules.tar.zst node_modules
       - name: upload artifacts
         if: ${{ needs.set-environment.outputs.should_deploy }}
         uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4
@@ -134,10 +135,11 @@ jobs:
           # if `name` is not specified, it will download all artifacts
           path: artifacts/
       - name: extract artifacts
+        env:
+          ZSTD_NBTHREADS: 0 # tell zstd to automatically choose thread count
         run: |
-          tar -xavf artifacts/build.tar.zst &
-          tar -xavf artifacts/node_modules.tar.zst &
-          wait
+          tar -xavf artifacts/build.tar.zst
+          tar -xavf artifacts/node_modules.tar.zst
       - name: deploy
         run: echo TEMP TURNED OFF FOR TESTING npm run deploy
         env:
@@ -170,10 +172,11 @@ jobs:
           # if `name` is not specified, it will download all artifacts
           path: artifacts/
       - name: extract artifacts
+        env:
+          ZSTD_NBTHREADS: 0 # tell zstd to automatically choose thread count
         run: |
-          tar -xavf artifacts/build.tar.zst &
-          tar -xavf artifacts/node_modules.tar.zst &
-          wait
+          tar -xavf artifacts/build.tar.zst
+          tar -xavf artifacts/node_modules.tar.zst
       - name: integration tests
         run: |
           if [ '${{ needs.set-environment.outputs.environment }}' == 'production' ]; then

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -126,7 +126,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [set-environment, build]
     environment: ${{ needs.set-environment.outputs.environment }}
-    if: ${{ needs.set-environment.outputs.should_deploy == 'true' }}
+    # if: ${{ needs.set-environment.outputs.should_deploy == 'true' }}
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
       - uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -125,7 +125,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [set-environment, build]
     environment: ${{ needs.set-environment.outputs.environment }}
-    # if: ${{ needs.set-environment.outputs.should_deploy == 'true' }}
+    if: ${{ needs.set-environment.outputs.should_deploy == 'true' }}
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
       - uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4
@@ -153,7 +153,7 @@ jobs:
           tar -xavf artifacts/build.tar.zst
           tar -xavf artifacts/node_modules.tar.zst
       - name: deploy
-        run: echo TEMP TURNED OFF FOR TESTING npm run deploy
+        run: npm run deploy
         env:
           S3_LOCAL_DIR: build
           S3_BUCKET_NAME: ${{ secrets.S3_BUCKET_NAME }}
@@ -171,7 +171,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: [set-environment, deploy]
     environment: ${{ needs.set-environment.outputs.environment }}
-    # if: ${{ needs.set-environment.outputs.should_deploy == 'true' }}
+    # GHA can't reach staging
+    # TODO: run integration tests against localhost?
+    if: ${{ needs.set-environment.outputs.environment == 'production' }}
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
       - uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4
@@ -194,15 +196,10 @@ jobs:
           tar -xavf artifacts/node_modules.tar.zst
       - name: integration tests
         run: |
-          # if [ '${{ needs.set-environment.outputs.environment }}' == 'production' ]; then
-            # if the health test fails, there's no point in trying to run the integration tests
-            npm run test:health
-            # health test succeeded, so proceed with integration tests
-            JEST_JUNIT_OUTPUT_NAME=integration-jest-results.xml npm run test:integration -- --reporters=jest-junit
-          # else
-          #   echo "Skipping integration tests for non-production environment"
-          #   echo "Please run the integration tests manually if necessary"
-          # fi
+          # if the health test fails, there's no point in trying to run the integration tests
+          npm run test:health
+          # health test succeeded, so proceed with integration tests
+          JEST_JUNIT_OUTPUT_NAME=integration-jest-results.xml npm run test:integration -- --reporters=jest-junit
         env:
           ROOT_URL: ${{ secrets.ROOT_URL }}
 

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -5,6 +5,10 @@ on:
   push: # Runs whenever a commit is pushed to the repository
     branches: [master, develop, beta, hotfix/*] # ...on any of these branches
   workflow_dispatch: # Allows you to run this workflow manually from the Actions tab
+  workflow_run: # Runs whenever another workflow is run
+    workflows: ["Create release branch and PRs"] # ...specifically, when this workflow is run
+    types:
+      - completed # ...after it completes
 
 concurrency:
   group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}'

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -118,12 +118,12 @@ jobs:
           path: artifacts/build.tar.zst
           compression-level: 0 # don't re-compress compressed data
       - name: debug node_modules cache key
-        run: find . -name .nvmrc -o -name package-lock.json -print0 | xargs -0 md5sum
+        run: md5sum .nvmrc package-lock.json
       - name: save node_modules for other jobs
         uses: actions/cache/save@v4
         with:
           path: node_modules
-          key: ${{ runner.os }}-node_modules-${{ hashFiles('**/.nvmrc', '**/package-lock.json') }}
+          key: ${{ runner.os }}-node_modules-${{ hashFiles('.nvmrc', 'package-lock.json') }}
   deploy:
     runs-on: ubuntu-latest
     needs: [set-environment, build]
@@ -135,13 +135,13 @@ jobs:
         with:
           node-version-file: '.nvmrc'
       - name: debug node_modules cache key
-        run: find . -name .nvmrc -o -name package-lock.json -print0 | xargs -0 md5sum
+        run: md5sum .nvmrc package-lock.json
       - name: retrieve node_modules
         uses: actions/cache/restore@v4
         with:
           fail-on-cache-miss: true
           path: node_modules
-          key: ${{ runner.os }}-node_modules-${{ hashFiles('**/.nvmrc', '**/package-lock.json') }}
+          key: ${{ runner.os }}-node_modules-${{ hashFiles('.nvmrc', 'package-lock.json') }}
       - name: setup Python
         uses: actions/setup-python@v5
         with:
@@ -193,7 +193,7 @@ jobs:
         with:
           fail-on-cache-miss: true
           path: node_modules
-          key: ${{ runner.os }}-node_modules-${{ hashFiles('**/.nvmrc', '**/package-lock.json') }}
+          key: ${{ runner.os }}-node_modules-${{ hashFiles('.nvmrc', 'package-lock.json') }}
       - name: download artifacts
         uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4
         with:

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -18,27 +18,34 @@ env:
   SKIP_CLEANUP: true
 
 jobs:
-  build-and-test-and-maybe-deploy:
+  set-environment: # this job just a trick to DRY the environment logic
     runs-on: ubuntu-latest
-    environment: >-
-      ${{
-        (
-          (github.ref == 'refs/heads/master') && 'production'
-        ) ||
-        (
-          (
-            (github.ref == 'refs/heads/develop') ||
-            (github.ref == 'refs/heads/beta') ||
-            startsWith(github.ref, 'refs/heads/hotfix/') ||
-            startsWith(github.ref, 'refs/heads/release/')
-          ) && 'staging'
-        ) ||
-        ''
-      }}
     env:
-      # SCRATCH_ENV comes from the GitHub Environment
-      # See https://github.com/scratchfoundation/scratch-www/settings/variables/actions
-      SCRATCH_SHOULD_DEPLOY: ${{ vars.SCRATCH_ENV != '' }}
+      GH_ENVIRONMENT: >-
+        ${{
+          (
+            (github.ref == 'refs/heads/master') && 'production'
+          ) ||
+          (
+            (
+              (github.ref == 'refs/heads/develop') ||
+              (github.ref == 'refs/heads/beta') ||
+              startsWith(github.ref, 'refs/heads/hotfix/') ||
+              startsWith(github.ref, 'refs/heads/release/')
+            ) && 'staging'
+          ) ||
+          ''
+        }}
+    outputs:
+      environment: ${{ env.GH_ENVIRONMENT }}
+      should_deploy: ${{ (env.GH_ENVIRONMENT || '') != '' }}
+  build:
+    runs-on: ubuntu-latest
+    needs: set-environment
+    environment: ${{ needs.set-environment.outputs.environment }}
+    env:
+      SCRATCH_ENV: ${{ needs.set-environment.outputs.environment }}
+      SCRATCH_SHOULD_DEPLOY: ${{ needs.set-environment.outputs.should_deploy }}
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
       - uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4
@@ -48,7 +55,7 @@ jobs:
       - name: info
         run: |
           cat <<EOF
-          Scratch environment: ${{ vars.SCRATCH_ENV }}
+          Scratch environment: ${SCRATCH_ENV}
           Node version: $(node --version)
           NPM version: $(npm --version)
           github.workflow: ${{ github.workflow }}
@@ -77,7 +84,6 @@ jobs:
           CLOUDDATA_HOST: ${{ secrets.CLOUDDATA_HOST }}
           PROJECT_HOST: ${{ secrets.PROJECT_HOST }}
           STATIC_HOST: ${{ secrets.STATIC_HOST }}
-          SCRATCH_ENV: ${{ vars.SCRATCH_ENV }}
           ONBOARDING_TEST_ACTIVE: "${{ vars.ONBOARDING_TEST_ACTIVE }}"
           ONBOARDING_TEST_PROJECT_IDS: "${{ vars.ONBOARDING_TEST_PROJECT_IDS }}"
           ONBOARDING_TESTING_STARTING_DATE: "${{ vars.ONBOARDING_TESTING_STARTING_DATE }}"
@@ -92,8 +98,40 @@ jobs:
           JEST_JUNIT_OUTPUT_NAME=localization-jest-results.xml npm run test:unit:jest:localization -- --reporters=jest-junit
           npm run test:unit:tap -- --output-file ./test/results/unit-raw.tap
           npm run test:unit:convertReportToXunit
+      - name: compress artifacts
+        if: ${{ needs.set-environment.outputs.should_deploy }}
+        run: |
+          mkdir -p artifacts/
+          tar -cavf artifacts/build.tar.zst build &
+          tar -cavf artifacts/node_modules.tar.zst node_modules &
+          wait
+      - name: upload artifacts
+        if: ${{ needs.set-environment.outputs.should_deploy }}
+        uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4
+        with:
+          path: artifacts/
+          compression-level: 0 # don't re-compress the already compressed artifacts
+  deploy:
+    runs-on: ubuntu-latest
+    needs: [set-environment, build]
+    environment: ${{ needs.set-environment.outputs.environment }}
+    if: ${{ needs.set-environment.outputs.should_deploy }}
+    steps:
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
+      - uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4
+        with:
+          cache: 'npm'
+          node-version-file: '.nvmrc'
+      - name: download artifacts
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4
+        with:
+          name: artifacts
+      - name: extract artifacts
+        run: |
+          tar -xavf artifacts/build.tar.zst &
+          tar -xavf artifacts/node_modules.tar.zst &
+          wait
       - name: deploy
-        if: ${{ env.SCRATCH_SHOULD_DEPLOY == 'true' }}
         run: npm run deploy
         env:
           S3_LOCAL_DIR: build
@@ -103,15 +141,34 @@ jobs:
           FASTLY_API_KEY: ${{ secrets.FASTLY_API_KEY }}
           FASTLY_SERVICE_ID: ${{ secrets.FASTLY_SERVICE_ID }}
           SCRATCH_BRANCH: ${{ github.ref_name }}
-          SCRATCH_ENV: ${{ vars.SCRATCH_ENV }}
+          SCRATCH_ENV: ${{ needs.set-environment.outputs.environment }}
           SLACK_WEBHOOK_CIRCLECI_NOTIFICATIONS: ${{ secrets.SLACK_WEBHOOK_CIRCLECI_NOTIFICATIONS }} # TODO: rename or replace
           SLACK_WEBHOOK_ENGINEERING: ${{ secrets.SLACK_WEBHOOK_ENGINEERING }}
           SLACK_WEBHOOK_MODS: ${{ secrets.SLACK_WEBHOOK_MODS }}
           RADISH_URL: ${{ vars.RADISH_URL }}
-      - name: integration tests
-        if: ${{ env.SCRATCH_SHOULD_DEPLOY == 'true' }}
+  integration-tests:
+    runs-on: ubuntu-latest
+    needs: [set-environment, deploy]
+    environment: ${{ needs.set-environment.outputs.environment }}
+    if: ${{ needs.set-environment.outputs.should_deploy }}
+    steps:
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
+      - uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4
+        with:
+          cache: 'npm'
+          node-version-file: '.nvmrc'
+      - name: download artifacts
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4
+        with:
+          name: artifacts
+      - name: extract artifacts
         run: |
-          if [ '${{ vars.SCRATCH_ENV }}' == 'production' ]; then
+          tar -xavf artifacts/build.tar.zst &
+          tar -xavf artifacts/node_modules.tar.zst &
+          wait
+      - name: integration tests
+        run: |
+          if [ '${{ needs.set-environment.outputs.environment }}' == 'production' ]; then
             # if the health test fails, there's no point in trying to run the integration tests
             npm run test:health
             # health test succeeded, so proceed with integration tests
@@ -144,11 +201,3 @@ jobs:
           OWNED_UNSHARED_SCRATCH2_PROJECT_ID: ${{ secrets.OWNED_UNSHARED_SCRATCH2_PROJECT_ID }}
           TEST_STUDIO_ID: ${{ secrets.TEST_STUDIO_ID }}
           RATE_LIMIT_CHECK: ${{ secrets.RATE_LIMIT_CHECK }}
-      - name: compress artifact
-        if: ${{ env.SCRATCH_SHOULD_DEPLOY == 'true' }}
-        run: tar -czvf build.tgz build
-      - name: upload artifact
-        if: ${{ env.SCRATCH_SHOULD_DEPLOY == 'true' }}
-        uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4
-        with:
-          path: build.tgz

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -117,6 +117,8 @@ jobs:
           name: build
           path: artifacts/build.tar.zst
           compression-level: 0 # don't re-compress compressed data
+      - name: debug node_modules cache key
+        run: find . -name .nvmrc -o -name package-lock.json -print0 | xargs -0 md5sum
       - name: save node_modules for other jobs
         uses: actions/cache/save@v4
         with:
@@ -132,6 +134,8 @@ jobs:
       - uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4
         with:
           node-version-file: '.nvmrc'
+      - name: debug node_modules cache key
+        run: find . -name .nvmrc -o -name package-lock.json -print0 | xargs -0 md5sum
       - name: retrieve node_modules
         uses: actions/cache/restore@v4
         with:

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -69,11 +69,6 @@ jobs:
           github.head_ref: ${{ github.head_ref }}
           github.ref: ${{ github.ref }}
           EOF
-      - name: setup Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.13'
-      - run: pip install s3cmd==2.4.0
       - run: npm --production=false ci
       - run: mkdir -p ./test/results
       - name: lint
@@ -121,24 +116,30 @@ jobs:
     runs-on: ubuntu-latest
     needs: [set-environment, build]
     environment: ${{ needs.set-environment.outputs.environment }}
-    if: ${{ needs.set-environment.outputs.should_deploy }}
+    # if: ${{ needs.set-environment.outputs.should_deploy == 'true' }}
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
       - uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4
         with:
           cache: 'npm'
           node-version-file: '.nvmrc'
+      - name: setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+      - run: pip install s3cmd==2.4.0
       - name: download artifacts
         uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4
         with:
-          name: artifacts
+          # if `name` is not specified, it will download all artifacts
+          path: artifacts/
       - name: extract artifacts
         run: |
           tar -xavf artifacts/build.tar.zst &
           tar -xavf artifacts/node_modules.tar.zst &
           wait
       - name: deploy
-        run: npm run deploy
+        run: echo TEMP TURNED OFF FOR TESTING npm run deploy
         env:
           S3_LOCAL_DIR: build
           S3_BUCKET_NAME: ${{ secrets.S3_BUCKET_NAME }}
@@ -156,7 +157,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [set-environment, deploy]
     environment: ${{ needs.set-environment.outputs.environment }}
-    if: ${{ needs.set-environment.outputs.should_deploy }}
+    if: ${{ needs.set-environment.outputs.should_deploy == 'true' }}
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
       - uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4
@@ -166,7 +167,8 @@ jobs:
       - name: download artifacts
         uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4
         with:
-          name: artifacts
+          # if `name` is not specified, it will download all artifacts
+          path: artifacts/
       - name: extract artifacts
         run: |
           tar -xavf artifacts/build.tar.zst &

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -138,6 +138,7 @@ jobs:
         env:
           ZSTD_NBTHREADS: 0 # tell zstd to automatically choose thread count
         run: |
+          ls -lRh artifacts/
           tar -xavf artifacts/build.tar.zst
           tar -xavf artifacts/node_modules.tar.zst
       - name: deploy

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -23,6 +23,7 @@ env:
 
 jobs:
   set-environment: # this job just a trick to DRY the environment logic
+    name: Set Environment
     runs-on: ubuntu-latest
     env:
       GH_ENVIRONMENT: >-
@@ -49,6 +50,7 @@ jobs:
       environment: ${{ env.GH_ENVIRONMENT }}
       should_deploy: ${{ (env.GH_ENVIRONMENT || '') != '' }}
   build:
+    name: Build and Unit Tests
     runs-on: ubuntu-latest
     needs: set-environment
     environment: ${{ needs.set-environment.outputs.environment }}
@@ -124,6 +126,7 @@ jobs:
           path: node_modules
           key: ${{ runner.os }}-node_modules-${{ hashFiles('.nvmrc', 'package-lock.json') }}
   deploy:
+    name: Deploy
     runs-on: ubuntu-latest
     needs: [set-environment, build]
     environment: ${{ needs.set-environment.outputs.environment }}
@@ -174,6 +177,7 @@ jobs:
           SLACK_WEBHOOK_MODS: ${{ secrets.SLACK_WEBHOOK_MODS }}
           RADISH_URL: ${{ vars.RADISH_URL }}
   integration-tests:
+    name: Production Integration Tests
     runs-on: ubuntu-latest
     needs: [set-environment, deploy]
     environment: ${{ needs.set-environment.outputs.environment }}

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -110,7 +110,6 @@ jobs:
         run: |
           mkdir -p artifacts/
           tar -cavf artifacts/build.tar.zst build
-          tar -cavf artifacts/node_modules.tar.zst node_modules
       - name: "upload artifact: build"
         if: ${{ needs.set-environment.outputs.should_deploy }}
         uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4
@@ -118,13 +117,11 @@ jobs:
           name: build
           path: artifacts/build.tar.zst
           compression-level: 0 # don't re-compress compressed data
-      - name: "upload artifact: node_modules"
-        if: ${{ needs.set-environment.outputs.should_deploy }}
-        uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4
+      - name: save node_modules for other jobs
+        uses: actions/cache/save@v4
         with:
-          name: node_modules
-          path: artifacts/node_modules.tar.zst
-          compression-level: 0 # don't re-compress compressed data
+          path: node_modules
+          key: ${{ runner.os }}-node_modules-${{ hashFiles('**/.nvmrc', '**/package-lock.json') }}
   deploy:
     runs-on: ubuntu-latest
     needs: [set-environment, build]
@@ -134,8 +131,13 @@ jobs:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
       - uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4
         with:
-          cache: 'npm'
           node-version-file: '.nvmrc'
+      - name: retrieve node_modules
+        uses: actions/cache/restore@v4
+        with:
+          fail-on-cache-miss: true
+          path: node_modules
+          key: ${{ runner.os }}-node_modules-${{ hashFiles('**/.nvmrc', '**/package-lock.json') }}
       - name: setup Python
         uses: actions/setup-python@v5
         with:
@@ -155,7 +157,6 @@ jobs:
         run: |
           ls -lRh artifacts/
           tar -xavf artifacts/build.tar.zst
-          tar -xavf artifacts/node_modules.tar.zst
       - name: deploy
         run: npm run deploy
         env:
@@ -182,8 +183,13 @@ jobs:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
       - uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4
         with:
-          cache: 'npm'
           node-version-file: '.nvmrc'
+      - name: retrieve node_modules
+        uses: actions/cache/restore@v4
+        with:
+          fail-on-cache-miss: true
+          path: node_modules
+          key: ${{ runner.os }}-node_modules-${{ hashFiles('**/.nvmrc', '**/package-lock.json') }}
       - name: download artifacts
         uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4
         with:
@@ -197,7 +203,6 @@ jobs:
           ZSTD_NBTHREADS: 0 # tell zstd to automatically choose thread count
         run: |
           tar -xavf artifacts/build.tar.zst
-          tar -xavf artifacts/node_modules.tar.zst
       - name: integration tests
         run: |
           # if the health test fails, there's no point in trying to run the integration tests

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -171,7 +171,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [set-environment, deploy]
     environment: ${{ needs.set-environment.outputs.environment }}
-    if: ${{ needs.set-environment.outputs.should_deploy == 'true' }}
+    # if: ${{ needs.set-environment.outputs.should_deploy == 'true' }}
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
       - uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4
@@ -194,15 +194,15 @@ jobs:
           tar -xavf artifacts/node_modules.tar.zst
       - name: integration tests
         run: |
-          if [ '${{ needs.set-environment.outputs.environment }}' == 'production' ]; then
+          # if [ '${{ needs.set-environment.outputs.environment }}' == 'production' ]; then
             # if the health test fails, there's no point in trying to run the integration tests
             npm run test:health
             # health test succeeded, so proceed with integration tests
             JEST_JUNIT_OUTPUT_NAME=integration-jest-results.xml npm run test:integration -- --reporters=jest-junit
-          else
-            echo "Skipping integration tests for non-production environment"
-            echo "Please run the integration tests manually if necessary"
-          fi
+          # else
+          #   echo "Skipping integration tests for non-production environment"
+          #   echo "Please run the integration tests manually if necessary"
+          # fi
         env:
           ROOT_URL: ${{ secrets.ROOT_URL }}
 


### PR DESCRIPTION
I wasn't sure who would be best to review this, so I just assigned a bunch of people. :partying_face:

### Resolves:

- Resolves POD-116

### Changes:

I recommend looking at this diff with "Hide whitespace" turned on (or add `?w=1` or `&w=1` to the end of the URL).

#### Break the CI/CD workflow into multiple parts

This will allow us to re-run a deploy. The primary use case I have in mind is if we need to switch our staging environment between different things we want to test, but it also means we can rerun a deploy if anything went wrong. Also also, we can now re-run integration tests without repeating the build and deploy steps, which might be useful in case of flaky tests.

#### Trigger the CI/CD workflow on completion of the "Create release branch and PRs" workflow

By default, GHA prevents a push from one workflow triggering another workflow. That's meant to protect against infinite loops and such, but it also means that as of migrating to GHA, making release PRs stopped automatically deploying the release candidate to staging. There are several different ways to make this work; I think what I've done here is the simplest, though it has the downside that looking at `prepare-release.yml` doesn't make it clear that it will trigger a build & deploy.

#### Compress and upload artifacts differently

In the middle of this work, I used `actions/upload-artifact` and `actions/download-artifact` to communicate `node_modules` between jobs, which we were already using to store the build output. To (try to) save time and/or space, I switched to using `zstd` instead of `gzip` for both artifacts. I later switched to using `actions/cache` for `node_modules` instead, which internally uses `zstd` anyway, but I left the `zstd` change for the build output artifact as a nice-to-have.

I also added a line to tell `upload-artifact` not to try to re-compress the already-compressed file. It still wraps it in a ZIP: that's a current limitation of `actions/upload-artifact` (see actions/upload-artifact#426).

### Test Coverage:

I tested the linkage between the jobs by temporarily turning off some of the conditionals, but I have not yet tested deploying, including for a release branch. After merging this change, I'll make a pretend release branch as a test.