### PR TITLE
feat[POD-182]: Update text of donation banner

### DIFF
--- a/src/views/splash/donate/donate-banner.jsx
+++ b/src/views/splash/donate/donate-banner.jsx
@@ -8,19 +8,7 @@ const Button = require('../../../components/forms/button.jsx');
 
 require('./donate-banner.scss');
 
-const SCRATCH_CAMPAIGN_BANNER_END_TIME = new Date(2025, 0, 9).getTime(); // January 9, 2025 (months are zero indexed)
-
-// This must be dynamic for our tests to work correctly
-const isCampaignActive = () => Date.now() < SCRATCH_CAMPAIGN_BANNER_END_TIME;
-
-const getDonateInfo = () => (isCampaignActive() ? {
-    bannerText: <FormattedMessage
-        id="donatebanner.eoyCampaign"
-        // values={{
-        // }}
-    />,
-    buttonLink: 'https://www.scratchfoundation.org/donate?utm_source=SCRATCH&utm_medium=BANNER&utm_campaign=EOY_GIVING'
-} : {
+const getDonateInfo = () => ({
     bannerText: <FormattedMessage id="donatebanner.askSupport" />,
     buttonLink: 'https://www.scratchfoundation.org/donate'
 });

--- a/src/views/splash/l10n.json
+++ b/src/views/splash/l10n.json
@@ -29,8 +29,7 @@
     "intro.watchVideo": "Watch Video",
     "news.scratchNews": "Scratch News",
 
-    "donatebanner.askSupport": "Scratch is the world's largest free coding community for kids. Your support makes a difference.",
-    "donatebanner.eoyCampaign": "Scratch is a nonprofit that relies on donations to keep our platform free for all kids. Your gift of $5 will make a difference.",
+    "donatebanner.askSupport": "Scratch is a nonprofit that relies on donations to keep our platform free for all kids. Your gift of $5 will make a difference.",
     "donatebanner.scratchWeek": "May 19-20 is Scratch’s 15th Anniversary! {celebrationLink}. Donate to support creative coding worldwide.",
     "donatebanner.learnMore": "Learn more",
 

--- a/test/unit/components/donate-banner.test.jsx
+++ b/test/unit/components/donate-banner.test.jsx
@@ -11,27 +11,12 @@ describe('DonateBannerTest', () => {
     afterEach(() => {
         global.Date.now = realDateNow;
     });
-    test('Testing 2024 EOY campaign message', () => {
-        global.Date.now = () => new Date(2024, 11, 16).getTime();
-        const component = mountWithIntl(
-            <DonateTopBanner />
-        );
-
-        expect(component.find('div.donate-banner').exists()).toEqual(true);
-        expect(component.find('p.donate-text').exists()).toEqual(true);
-        expect(component.find('FormattedMessage[id="donatebanner.eoyCampaign"]').exists()).toEqual(true);
-        expect(component.find('FormattedMessage[id="donatebanner.askSupport"]').exists()).toEqual(false);
-
-    });
-    test('testing default message comes back after January 9, 2025', () => {
-        // Date after Scratch week
-        global.Date.now = () => new Date(2025, 0, 10).getTime();
+    test('testing default message', () => {
         const component = mountWithIntl(
             <DonateTopBanner />
         );
         expect(component.find('div.donate-banner').exists()).toEqual(true);
         expect(component.find('p.donate-text').exists()).toEqual(true);
         expect(component.find('FormattedMessage[id="donatebanner.askSupport"]').exists()).toEqual(true);
-        expect(component.find('FormattedMessage[id="donatebanner.eoyCampaign"]').exists()).toEqual(false);
     });
 });


### PR DESCRIPTION
### Resolves:

[POD-182]

### Changes:

Update the text of the banner that shows when a user is logged out. Remove the logic that differentiated between the regular banner and the end of year campaign banner.

### Test Coverage:

Relevant tests are updated, all tests pass


[POD-182]: https://scratchfoundation.atlassian.net/browse/POD-182?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ