### PR TITLE
Fixed Carousel Formatting on Homepage

### DIFF
--- a/src/components/carousel/carousel.scss
+++ b/src/components/carousel/carousel.scss
@@ -72,7 +72,8 @@
     }
 
     .slick-slide {
-        padding-right: 30px;
+        // border: 1px dashed red; --> see the last photo overlap into next slide
+        padding-right: 24px;
     }
 
 }


### PR DESCRIPTION
### Resolves:

front page sections show two rows when you click next multiple times #9253

### Changes:

Fixed carousel formatting on homepage. The issue was given the "padding-right", originally set to 30 px, on the individual images the box would spill over into the next slide and would push the last image to the front of the carousel. I changes the padding to be 24 px so that all 5 images appear on a given slide.

### Test Coverage:

## Testing: running npm test
<img width="1438" alt="Screenshot 2025-04-13 at 4 02 56 PM" src="https://github.com/user-attachments/assets/c12ccd65-3c81-4eae-b943-460a9908a048" />

## Locally: running npm start
# Before change -->
<img width="1438" alt="Screenshot 2025-04-13 at 4 27 56 PM" src="https://github.com/user-attachments/assets/23812245-fb07-44a4-9e43-5f3de846f7c6" />

Issue seen here, once you click to the next slide, the last image doesn't appear until you click back to the beginning slide

<img width="1440" alt="Screenshot 2025-04-13 at 4 28 04 PM" src="https://github.com/user-attachments/assets/f730bf7e-782c-4ce6-abed-e7a9ba8997cb" />
<img width="1440" alt="Screenshot 2025-04-13 at 4 28 09 PM" src="https://github.com/user-attachments/assets/447a39fe-afe2-4c2d-bb63-102de14afdfb" />

# After Change -->

<img width="1440" alt="Screenshot 2025-04-13 at 4 28 25 PM" src="https://github.com/user-attachments/assets/3800789c-5a34-4705-a34e-da678f1b32f7" />

<img width="1440" alt="Screenshot 2025-04-13 at 4 28 30 PM" src="https://github.com/user-attachments/assets/3730f9c7-049f-4040-b641-09d77c425111" />

