### PR TITLE
Lower excessive redirects

### DIFF
--- a/src/views/become-a-scratcher/become-a-scratcher.jsx
+++ b/src/views/become-a-scratcher/become-a-scratcher.jsx
@@ -67,7 +67,7 @@ const OnboardingHeader = ({user, section, secondary}) => {
                         className="profile-page-image"
                         src="/images/onboarding/profile-page-become-a-scratcher-button.svg"
                     />
-                    <a href={`/users/${user.username}`}>
+                    <a href={`/users/${user.username}/`}>
                         <Button>
                             <FormattedMessage
                                 id={'becomeAScratcher.buttons.backToProfile'}

--- a/src/views/contact-us/contact-us.jsx
+++ b/src/views/contact-us/contact-us.jsx
@@ -31,7 +31,7 @@ class ContactUs extends React.Component {
         } else if (query.indexOf('profile=') !== -1) {
             scratchId = query.match(/profile=([a-zA-Z0-9-_]+)/)[1];
             this.state.subject = `Issue reported with profile ${scratchId}`;
-            this.state.body = `https://scratch.mit.edu/users/${scratchId}`;
+            this.state.body = `https://scratch.mit.edu/users/${scratchId}/`;
         } else if (query.indexOf('confirmation=') !== -1) {
             this.state.subject = 'Problem with email confirmation';
         }

--- a/src/views/messages/message-rows/comment-message.jsx
+++ b/src/views/messages/message-rows/comment-message.jsx
@@ -161,7 +161,7 @@ class CommentMessage extends React.Component {
                     {this.getMessageText(this.props.objectType, this.props.commentee)}
                 </p>
                 <FlexRow className="mod-comment-message">
-                    <a href={`/users/${this.props.actorUsername}`}>
+                    <a href={`/users/${this.props.actorUsername}/`}>
                         <img
                             alt={`${this.props.actorUsername}'s avatar`}
                             className="comment-message-info-img"

--- a/src/views/messages/message-rows/favorite-project.jsx
+++ b/src/views/messages/message-rows/favorite-project.jsx
@@ -21,7 +21,7 @@ const FavoriteProjectMessage = props => (
                 profileLink: (
                     <a
                         className="social-messages-profile-link"
-                        href={`/users/${props.actorUsername}`}
+                        href={`/users/${props.actorUsername}/`}
                     >
                         {props.actorUsername}
                     </a>

--- a/src/views/messages/message-rows/love-project.jsx
+++ b/src/views/messages/message-rows/love-project.jsx
@@ -21,7 +21,7 @@ const LoveProjectMessage = props => (
                 profileLink: (
                     <a
                         className="social-messages-profile-link"
-                        href={`/users/${props.actorUsername}`}
+                        href={`/users/${props.actorUsername}/`}
                     >
                         {props.actorUsername}
                     </a>

--- a/src/views/messages/message-rows/remix-project.jsx
+++ b/src/views/messages/message-rows/remix-project.jsx
@@ -21,7 +21,7 @@ const RemixProjectMessage = props => (
                 profileLink: (
                     <a
                         className="social-messages-profile-link"
-                        href={`/users/${props.actorUsername}`}
+                        href={`/users/${props.actorUsername}/`}
                     >
                         {props.actorUsername}
                     </a>

--- a/src/views/splash/activity-rows/favorite-project.jsx
+++ b/src/views/splash/activity-rows/favorite-project.jsx
@@ -18,7 +18,7 @@ const FavoriteProjectMessage = props => (
             id="messages.favoriteText"
             values={{
                 profileLink: (
-                    <a href={`/users/${props.actorUsername}`}>
+                    <a href={`/users/${props.actorUsername}/`}>
                         {props.actorUsername}
                     </a>
                 ),

--- a/src/views/splash/activity-rows/remix-project.jsx
+++ b/src/views/splash/activity-rows/remix-project.jsx
@@ -18,7 +18,7 @@ const RemixProjectMessage = props => (
             id="messages.remixText"
             values={{
                 profileLink: (
-                    <a href={`/users/${props.actorUsername}`}>
+                    <a href={`/users/${props.actorUsername}/`}>
                         {props.actorUsername}
                     </a>
                 ),

--- a/src/views/splash/activity-rows/share-project.jsx
+++ b/src/views/splash/activity-rows/share-project.jsx
@@ -18,7 +18,7 @@ const ShareProjectMessage = props => (
             id="messages.shareText"
             values={{
                 profileLink: (
-                    <a href={`/users/${props.actorUsername}`}>
+                    <a href={`/users/${props.actorUsername}/`}>
                         {props.actorUsername}
                     </a>
                 ),

--- a/src/views/studio/studio-activity.jsx
+++ b/src/views/studio/studio-activity.jsx
@@ -27,7 +27,7 @@ const getComponentForItem = item => {
                     id="studio.activityAddProjectToStudio"
                     values={{
                         profileLink: (
-                            <a href={`/users/${item.actor_username}`}>
+                            <a href={`/users/${item.actor_username}/`}>
                                 {item.actor_username}
                             </a>
                         ),
@@ -53,7 +53,7 @@ const getComponentForItem = item => {
                     id="studio.activityRemoveProjectStudio"
                     values={{
                         profileLink: (
-                            <a href={`/users/${item.actor_username}`}>
+                            <a href={`/users/${item.actor_username}/`}>
                                 {item.actor_username}
                             </a>
                         ),
@@ -79,7 +79,7 @@ const getComponentForItem = item => {
                     id="studio.activityUpdateStudio"
                     values={{
                         profileLink: (
-                            <a href={`/users/${item.actor_username}`}>
+                            <a href={`/users/${item.actor_username}/`}>
                                 {item.actor_username}
                             </a>
                         )
@@ -101,12 +101,12 @@ const getComponentForItem = item => {
                     values={{
                         // Beware, DB seems to think actor is new curator and username is inviter
                         newCuratorProfileLink: (
-                            <a href={`/users/${item.actor_username}`}>
+                            <a href={`/users/${item.actor_username}/`}>
                                 {item.actor_username}
                             </a>
                         ),
                         inviterProfileLink: (
-                            <a href={`/users/${item.username}`}>
+                            <a href={`/users/${item.username}/`}>
                                 {item.username}
                             </a>
                         )
@@ -127,12 +127,12 @@ const getComponentForItem = item => {
                     id="studio.activityRemoveCurator"
                     values={{
                         removedProfileLink: (
-                            <a href={`/users/${item.username}`}>
+                            <a href={`/users/${item.username}/`}>
                                 {item.username}
                             </a>
                         ),
                         removerProfileLink: (
-                            <a href={`/users/${item.actor_username}`}>
+                            <a href={`/users/${item.actor_username}/`}>
                                 {item.actor_username}
                             </a>
                         )
@@ -153,12 +153,12 @@ const getComponentForItem = item => {
                     id="studio.activityBecomeOwner"
                     values={{
                         promotedProfileLink: (
-                            <a href={`/users/${item.recipient_username}`}>
+                            <a href={`/users/${item.recipient_username}/`}>
                                 {item.recipient_username}
                             </a>
                         ),
                         promotorProfileLink: (
-                            <a href={`/users/${item.actor_username}`}>
+                            <a href={`/users/${item.actor_username}/`}>
                                 {item.actor_username}
                             </a>
                         )
@@ -180,7 +180,7 @@ const getComponentForItem = item => {
                         id="studio.activityBecomeHostAdminActor"
                         values={{
                             newHostProfileLink: (
-                                <a href={`/users/${item.recipient_username}`}>
+                                <a href={`/users/${item.recipient_username}/`}>
                                     {item.recipient_username}
                                 </a>
                             )
@@ -190,12 +190,12 @@ const getComponentForItem = item => {
                         id="studio.activityBecomeHost"
                         values={{
                             newHostProfileLink: (
-                                <a href={`/users/${item.recipient_username}`}>
+                                <a href={`/users/${item.recipient_username}/`}>
                                     {item.recipient_username}
                                 </a>
                             ),
                             actorProfileLink: (
-                                <a href={`/users/${item.actor_username}`}>
+                                <a href={`/users/${item.actor_username}/`}>
                                     {item.actor_username}
                                 </a>
                             )

--- a/src/views/studio/studio-member-tile.jsx
+++ b/src/views/studio/studio-member-tile.jsx
@@ -37,7 +37,7 @@ const StudioMemberTile = ({
     const [transferHostModalOpen, setTransferHostModalOpen] = useState(false);
     const [managerLimitReached, setManagerLimitReached] = useState(false);
     const {errorAlert, successAlert} = useAlertContext();
-    const userUrl = `/users/${username}`;
+    const userUrl = `/users/${username}/`;
     return (
         <div className="studio-member-tile">
             <a href={userUrl}>

--- a/src/views/studio/studio-project-tile.jsx
+++ b/src/views/studio/studio-project-tile.jsx
@@ -18,7 +18,7 @@ const StudioProjectTile = ({
 }) => {
     const [submitting, setSubmitting] = useState(false);
     const projectUrl = `/projects/${id}`;
-    const userUrl = `/users/${username}`;
+    const userUrl = `/users/${username}/`;
     const {errorAlert} = useContext(AlertContext);
     return (
         <div className="studio-project-tile">


### PR DESCRIPTION
hrefs for /users/:username without a trailing / lead to django kicking back a redirect to /users/:username/ This activity leads to scratch-www-production having an extremely high number of redirects when compared to all other requests. It would be useful to clear this noise up for SRE related operations.

I have kept edits away from `preview` routes as I believe they are no longer in use.