### PR TITLE
feat: disallow students from creating notifications

### DIFF
--- a/src/redux/session.js
+++ b/src/redux/session.js
@@ -157,6 +157,7 @@ module.exports.selectIsAdmin = state => get(state, ['session', 'session', 'permi
 module.exports.selectUser = state => get(state, ['session', 'session', 'user'], false);
 module.exports.selectIsSocial = state => get(state, ['session', 'session', 'permissions', 'social'], false);
 module.exports.selectIsEducator = state => get(state, ['session', 'session', 'permissions', 'educator'], false);
+module.exports.selectIsStudent = state => get(state, ['session', 'session', 'permissions', 'student'], false);
 module.exports.selectProjectCommentsGloballyEnabled = state =>
     get(state, ['session', 'session', 'flags', 'project_comments_enabled'], false);
 module.exports.selectStudioCommentsGloballyEnabled = state =>

--- a/src/redux/studio-permissions.js
+++ b/src/redux/studio-permissions.js
@@ -1,6 +1,7 @@
 const {selectUserId, selectIsAdmin, selectIsSocial,
     selectIsLoggedIn, selectUsername, selectIsMuted,
-    selectHasFetchedSession, selectStudioCommentsGloballyEnabled} = require('./session');
+    selectHasFetchedSession, selectStudioCommentsGloballyEnabled,
+    selectIsStudent } = require('./session');
 
 // Fine-grain selector helpers - not exported, use the higher level selectors below
 const isHost = state => selectUserId(state) === state.studio.host;
@@ -39,7 +40,9 @@ const selectCanEditCommentsAllowed = state => !selectIsMuted(state) && (selectIs
 const selectCanEditOpenToAll = state => !selectIsMuted(state) && isManager(state);
 
 const selectShowCuratorInvite = state => !selectIsMuted(state) && !!state.studio.invited;
-const selectCanInviteCurators = state => !selectIsMuted(state) && isManager(state);
+// Students should not be able to create studios, this is to address already existing ones.
+// See https://scratchfoundation.atlassian.net/browse/POD-220
+const selectCanInviteCurators = state => !selectIsMuted(state) && !selectIsStudent(state) && isManager(state);
 const selectCanRemoveCurator = (state, username) => {
     if (selectIsMuted(state)) return false;
     // Admins/managers can remove any curators

--- a/src/redux/studio-permissions.js
+++ b/src/redux/studio-permissions.js
@@ -1,7 +1,7 @@
 const {selectUserId, selectIsAdmin, selectIsSocial,
     selectIsLoggedIn, selectUsername, selectIsMuted,
     selectHasFetchedSession, selectStudioCommentsGloballyEnabled,
-    selectIsStudent } = require('./session');
+    selectIsStudent} = require('./session');
 
 // Fine-grain selector helpers - not exported, use the higher level selectors below
 const isHost = state => selectUserId(state) === state.studio.host;


### PR DESCRIPTION
### Resolves:
https://scratchfoundation.atlassian.net/browse/POD-220

### Changes:

Hide the 'Invite Curators' section in the Curators view in the studio view if the user is a student, even in the case where the user is the owner of the studio.

![image](https://github.com/user-attachments/assets/c271e34b-5682-482c-b049-725caccf8b2e)


