### PR TITLE
fix non-English remix notifications (update scratch-l10n)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -112,7 +112,7 @@
         "regenerator-runtime": "0.13.9",
         "sass": "1.87.0",
         "sass-loader": "10.5.2",
-        "scratch-l10n": "5.0.222",
+        "scratch-l10n": "5.0.247",
         "selenium-webdriver": "4.31.0",
         "slick-carousel": "1.8.1",
         "stream-browserify": "3.0.0",
@@ -22611,9 +22611,9 @@
       }
     },
     "node_modules/scratch-l10n": {
-      "version": "5.0.222",
-      "resolved": "https://registry.npmjs.org/scratch-l10n/-/scratch-l10n-5.0.222.tgz",
-      "integrity": "sha512-h9Pug8xCi5OVUu6WbaRBjHkkwJBsddWmok0pqrAc431SSfr74bjNF3iqjAu7CiFE0WxWa3ALl+n3xd002dCjjQ==",
+      "version": "5.0.247",
+      "resolved": "https://registry.npmjs.org/scratch-l10n/-/scratch-l10n-5.0.247.tgz",
+      "integrity": "sha512-8pzXJ9zbzK3MxGJ+kqF28EU0w9S/sFUK2onOqSO2BDc/ANjm03DYYLstEY4TTysNW+aLqyfv85neCNm4o6gjIw==",
       "dev": true,
       "license": "AGPL-3.0-only",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -147,7 +147,7 @@
     "regenerator-runtime": "0.13.9",
     "sass": "1.87.0",
     "sass-loader": "10.5.2",
-    "scratch-l10n": "5.0.222",
+    "scratch-l10n": "5.0.247",
     "selenium-webdriver": "4.31.0",
     "slick-carousel": "1.8.1",
     "stream-browserify": "3.0.0",


### PR DESCRIPTION
### Resolves

- Resolves POD-225 "Remix notifications broken when for all languages but English"

### Changes

Update `scratch-l10n` to the latest version.

The reason this broke is that #9472 changed the placeholders in the remix message but did not change the message ID. If the message lookup had failed, the English text (with correct placeholders) would have been used. Since the message ID didn't change, looking up non-English versions of the message in `scratch-l10n` succeeded, but resulted in the old translated message with the old placeholders. Since the placeholders didn't match up, variable replacement didn't work correctly, and the message ended up looking something like this:

![image](https://github.com/user-attachments/assets/f943932d-351f-44fd-8a8a-8ed3860e536a)

Updating `scratch-l10n` gets the new placeholders, which will cause variable replacement to work correctly. Most languages don't have a translation for this message yet, but the links will be fixed. Translations for this message can come online in future updates.

### Test Coverage:

Verified correct message rendering in staging