### PR TITLE
fix: move files loading translated tutorial images to default static …

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -244,8 +244,15 @@ module.exports = {
                     to: 'static/blocks-media'
                 },
                 {
-                    from: 'node_modules/@scratch/scratch-gui/dist/chunks',
-                    to: 'chunks'
+                    context: 'node_modules/@scratch/scratch-gui/dist/',
+                    from: 'chunks/fetch-worker.*.{js,js.map}',
+                },
+                {
+                    context: 'node_modules/@scratch/scratch-gui/dist/',
+                    // Copy the scripts for loading the translated images
+                    // Their chunks are expected to be on the same path as the assets themselves.
+                    from: 'chunks/*-steps.*.{js,js.map}',
+                    to: 'js'
                 },
                 {
                     from: 'node_modules/@scratch/scratch-gui/dist/extension-worker.js'

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -245,7 +245,7 @@ module.exports = {
                 },
                 {
                     context: 'node_modules/@scratch/scratch-gui/dist/',
-                    from: 'chunks/fetch-worker.*.{js,js.map}',
+                    from: 'chunks/fetch-worker.*.{js,js.map}'
                 },
                 {
                     context: 'node_modules/@scratch/scratch-gui/dist/',


### PR DESCRIPTION
…path

### Resolves:

https://scratchfoundation.atlassian.net/browse/UEPR-260

### Changes:

Copy chunks with load translated tutorial image scripts into js.
Continue copying fetch-worker chunks in base folder
