### PR TITLE
feat: [POD-251] Search/explore admin

### DIFF
--- a/src/components/grid/grid.jsx
+++ b/src/components/grid/grid.jsx
@@ -1,6 +1,7 @@
 const classNames = require('classnames');
 const PropTypes = require('prop-types');
 const React = require('react');
+const {useCallback} = require('react');
 
 const Thumbnail = require('../thumbnail/thumbnail.jsx');
 const FlexRow = require('../flex-row/flex-row.jsx');
@@ -8,53 +9,63 @@ const thumbnailUrl = require('../../lib/user-thumbnail');
 
 require('./grid.scss');
 
-const Grid = props => (
-    <div className={classNames('grid', props.className)}>
-        <FlexRow>
-            {props.items.map((item, key) => {
-                const href = `/${props.itemType}/${item.id}/`;
-                if (props.itemType === 'projects') {
+const Grid = props => {
+    const handleRemove = useCallback(
+        item => () => {
+            if (props.onRemove) {
+                props.onRemove(item);
+            }
+        },
+        [props.onRemove]
+    );
+    return (
+        <div className={classNames('grid', props.className)}>
+            <FlexRow>
+                {props.items.map((item, key) => {
+                    const href = `/${props.itemType}/${item.id}/`;
+                    if (props.itemType === 'projects') {
+                        return (
+                            <Thumbnail
+                                avatar={thumbnailUrl(item.author.id)}
+                                creator={item.author.username}
+                                favorites={item.stats.favorites}
+                                href={href}
+                                key={key}
+                                loves={item.stats.loves}
+                                remixes={item.stats.remixes}
+                                showAvatar={props.showAvatar}
+                                showFavorites={props.showFavorites}
+                                showLoves={props.showLoves}
+                                showRemixes={props.showRemixes}
+                                showViews={props.showViews}
+                                showRemoveButton={props.showRemoveButton}
+                                src={item.image}
+                                title={item.title}
+                                type={'project'}
+                                views={item.stats.views}
+                                alt={item.alt}
+                                onRemove={handleRemove(item)}
+                            />
+                        );
+                    }
                     return (
                         <Thumbnail
-                            avatar={thumbnailUrl(item.author.id)}
-                            creator={item.author.username}
-                            favorites={item.stats.favorites}
                             href={href}
                             key={key}
-                            loves={item.stats.loves}
-                            remixes={item.stats.remixes}
-                            showAvatar={props.showAvatar}
-                            showFavorites={props.showFavorites}
-                            showLoves={props.showLoves}
-                            showRemixes={props.showRemixes}
-                            showViews={props.showViews}
-                            showRemoveButton={props.showRemoveButton}
+                            owner={item.owner}
                             src={item.image}
-                            title={item.title}
-                            type={'project'}
-                            views={item.stats.views}
                             alt={item.alt}
-                            onRemove={() => props.onRemove(item)}
+                            title={item.title}
+                            type={'gallery'}
+                            showRemoveButton={props.showRemoveButton}
+                            onRemove={handleRemove(item)}
                         />
                     );
-                }
-                return (
-                    <Thumbnail
-                        href={href}
-                        key={key}
-                        owner={item.owner}
-                        src={item.image}
-                        alt={item.alt}
-                        title={item.title}
-                        type={'gallery'}
-                        showRemoveButton={props.showRemoveButton}
-                        onRemove={() => props.onRemove(item)}
-                    />
-                );
-            })}
-        </FlexRow>
-    </div>
-);
+                })}
+            </FlexRow>
+        </div>
+    );
+};
 
 Grid.propTypes = {
     className: PropTypes.string,

--- a/src/components/grid/grid.jsx
+++ b/src/components/grid/grid.jsx
@@ -28,11 +28,13 @@ const Grid = props => (
                             showLoves={props.showLoves}
                             showRemixes={props.showRemixes}
                             showViews={props.showViews}
+                            showRemoveButton={props.showRemoveButton}
                             src={item.image}
                             title={item.title}
                             type={'project'}
                             views={item.stats.views}
                             alt={item.alt}
+                            onRemove={() => props.onRemove(item)}
                         />
                     );
                 }
@@ -45,6 +47,8 @@ const Grid = props => (
                         alt={item.alt}
                         title={item.title}
                         type={'gallery'}
+                        showRemoveButton={props.showRemoveButton}
+                        onRemove={() => props.onRemove(item)}
                     />
                 );
             })}
@@ -60,7 +64,9 @@ Grid.propTypes = {
     showFavorites: PropTypes.bool,
     showLoves: PropTypes.bool,
     showRemixes: PropTypes.bool,
-    showViews: PropTypes.bool
+    showViews: PropTypes.bool,
+    showRemoveButton: PropTypes.bool,
+    onRemove: PropTypes.func
 };
 
 Grid.defaultProps = {
@@ -70,7 +76,9 @@ Grid.defaultProps = {
     showFavorites: false,
     showRemixes: false,
     showViews: false,
-    showAvatar: false
+    showAvatar: false,
+    showRemoveButton: false,
+    onRemove: null
 };
 
 module.exports = Grid;

--- a/src/components/thumbnail/thumbnail-remove-button.jsx
+++ b/src/components/thumbnail/thumbnail-remove-button.jsx
@@ -1,8 +1,8 @@
 const React = require('react');
-const PropTypes = require('prop-types');
 require('./thumbnail-remove-button.scss');
+const PropTypes = require('prop-types');
 
-const ThumbnailRemoveButton = ({ onClick }) => (
+const ThumbnailRemoveButton = ({onClick}) => (
     <button
         className="thumbnail-remove-button"
         onClick={onClick}
@@ -13,5 +13,8 @@ const ThumbnailRemoveButton = ({ onClick }) => (
     </button>
 );
 
+ThumbnailRemoveButton.propTypes = {
+    onClick: PropTypes.func
+};
 
 module.exports = ThumbnailRemoveButton;

--- a/src/components/thumbnail/thumbnail-remove-button.jsx
+++ b/src/components/thumbnail/thumbnail-remove-button.jsx
@@ -1,0 +1,17 @@
+const React = require('react');
+const PropTypes = require('prop-types');
+require('./thumbnail-remove-button.scss');
+
+const ThumbnailRemoveButton = ({ onClick }) => (
+    <button
+        className="thumbnail-remove-button"
+        onClick={onClick}
+        title="Remove"
+        aria-label="Remove"
+    >
+        ✕
+    </button>
+);
+
+
+module.exports = ThumbnailRemoveButton;

--- a/src/components/thumbnail/thumbnail-remove-button.scss
+++ b/src/components/thumbnail/thumbnail-remove-button.scss
@@ -1,0 +1,22 @@
+@import "../../colors";
+
+.thumbnail-remove-button {
+    position: absolute;
+    top: -4px;
+    right: -4px;
+    background: $ui-white;
+    border: 1px solid $ui-border;
+    color: $type-gray;
+    font-size: 12px;
+    width: 24px;
+    height: 24px;
+    line-height: 24px;
+    text-align: center;
+    border-radius: 50%;
+    cursor: pointer;
+    z-index: 2;
+
+    &:hover {
+        background: $ui-border;
+    }
+}

--- a/src/components/thumbnail/thumbnail.jsx
+++ b/src/components/thumbnail/thumbnail.jsx
@@ -4,6 +4,8 @@ const React = require('react');
 
 require('./thumbnail.scss');
 
+const ThumbnailRemoveButton = require('./thumbnail-remove-button.jsx');
+
 const Thumbnail = props => {
     const extra = [];
     const info = [];
@@ -110,6 +112,7 @@ const Thumbnail = props => {
             </a>
         );
     }
+
     return (
         <div
             className={classNames(
@@ -126,6 +129,9 @@ const Thumbnail = props => {
                 </div>
             </div>
             {extra}
+            {props.showRemoveButton &&
+                <ThumbnailRemoveButton onClick={props.onRemove} />
+            }
         </div>
     );
 };
@@ -145,10 +151,12 @@ Thumbnail.propTypes = {
     showLoves: PropTypes.bool,
     showRemixes: PropTypes.bool,
     showViews: PropTypes.bool,
+    showRemoveButton: PropTypes.bool,
     src: PropTypes.string,
     title: PropTypes.string,
     type: PropTypes.string,
-    views: PropTypes.oneOfType([PropTypes.number, PropTypes.string])
+    views: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+    onRemove: PropTypes.func
 };
 
 Thumbnail.defaultProps = {
@@ -161,9 +169,11 @@ Thumbnail.defaultProps = {
     showLoves: false,
     showRemixes: false,
     showViews: false,
+    showRemoveButton: false,
     src: '',
     title: 'Project',
-    type: 'project'
+    type: 'project',
+    onRemove: null
 };
 
 module.exports = Thumbnail;

--- a/src/components/thumbnail/thumbnail.scss
+++ b/src/components/thumbnail/thumbnail.scss
@@ -1,6 +1,7 @@
 @import "../../colors";
 
 .thumbnail {
+    position: relative;
     .thumbnail-image {
         display: block;
 

--- a/src/views/explore/explore.jsx
+++ b/src/views/explore/explore.jsx
@@ -30,6 +30,7 @@ class Explore extends React.Component {
             'handleGetExploreMore',
             'handleChangeSortMode',
             'handleToggleRemoveButton',
+            'handleRemove',
             'getBubble'
         ]);
 
@@ -110,6 +111,24 @@ class Explore extends React.Component {
         this.setState({showRemoveButton: e.target.checked});
     }
 
+    handleRemove (item) {
+        // if (!window.confirm('Are you sure you want to remove this item from the search index?')) return;
+
+        // TODO: don't slice the itemType
+        api({
+            uri: `/admin/search/${this.state.itemType.slice(0, -1)}/${item.id}`,
+            method: 'DELETE'
+        }, (err, res) => {
+            if (err) {
+                alert('Error removing project.');
+                console.error(err);
+            } else {
+                const updated = this.state.loaded.filter(p => p.id !== item.id);
+                this.setState({loaded: updated});
+            }
+        });
+    }
+  
     getBubble (type) {
         const classes = classNames({
             active: (this.state.category === type)
@@ -249,7 +268,7 @@ class Explore extends React.Component {
                             showLoves={false}
                             showViews={false}
                             showRemoveButton={this.state.showRemoveButton}
-                            onRemove={(item) => { console.log(item) }}
+                            onRemove={this.handleRemove}
                         />
                         <Button
                             onClick={this.handleGetExploreMore}

--- a/src/views/explore/explore.jsx
+++ b/src/views/explore/explore.jsx
@@ -112,15 +112,13 @@ class Explore extends React.Component {
     }
 
     handleRemove (item) {
-        // if (!window.confirm('Are you sure you want to remove this item from the search index?')) return;
-
-        // TODO: don't slice the itemType
+        // TODO: don't slice the itemType (this was a hacky way to turn 'projects' --> 'project')
         api({
             uri: `/admin/search/${this.state.itemType.slice(0, -1)}/${item.id}`,
             method: 'DELETE'
-        }, (err, res) => {
+        }, err => {
             if (err) {
-                alert('Error removing project.');
+                alert('Error removing project.'); // eslint-disable-line no-alert
                 console.error(err);
             } else {
                 const updated = this.state.loaded.filter(p => p.id !== item.id);
@@ -291,8 +289,6 @@ Explore.propTypes = {
 const mapStateToProps = state => ({
     session: state.session
 });
-
-const WrappedExplore = injectIntl(Explore);
 
 const ConnectedExplore = connect(mapStateToProps)(injectIntl(Explore));
 render(<Page><ConnectedExplore /></Page>, document.getElementById('app'));

--- a/src/views/explore/explore.jsx
+++ b/src/views/explore/explore.jsx
@@ -4,9 +4,11 @@ const injectIntl = require('react-intl').injectIntl;
 const FormattedMessage = require('react-intl').FormattedMessage;
 const React = require('react');
 const render = require('../../lib/render.jsx');
+const {connect} = require('react-redux');
 
 const api = require('../../lib/api');
 const intlShape = require('../../lib/intl-shape');
+const PropTypes = require('prop-types');
 const {getLocale} = require('../../lib/locales.js');
 
 const Page = require('../../components/page/www/page.jsx');
@@ -222,16 +224,18 @@ class Explore extends React.Component {
                             />
                         </Form>
                     </div>
-                    <div className="sort-controls">
-                        <label>
-                            <span>Removal mode: </span>
-                            <input
-                                type="checkbox"
-                                checked={this.state.showRemoveButton}
-                                onChange={this.handleToggleRemoveButton}
-                            />
-                        </label>
-                    </div>
+                    {this.props.session?.session?.permissions?.admin && (
+                        <div className="sort-controls">
+                            <label>
+                                <span>Removal mode: </span>
+                                <input
+                                    type="checkbox"
+                                    checked={this.state.showRemoveButton}
+                                    onChange={this.handleToggleRemoveButton}
+                                />
+                            </label>
+                        </div>
+                    )}
                     <div
                         id="projectBox"
                         key="projectBox"
@@ -261,9 +265,15 @@ class Explore extends React.Component {
 }
 
 Explore.propTypes = {
-    intl: intlShape
+    intl: intlShape,
+    session: PropTypes.object
 };
+
+const mapStateToProps = state => ({
+    session: state.session
+});
 
 const WrappedExplore = injectIntl(Explore);
 
-render(<Page><WrappedExplore /></Page>, document.getElementById('app'));
+const ConnectedExplore = connect(mapStateToProps)(injectIntl(Explore));
+render(<Page><ConnectedExplore /></Page>, document.getElementById('app'));

--- a/src/views/explore/explore.jsx
+++ b/src/views/explore/explore.jsx
@@ -27,12 +27,14 @@ class Explore extends React.Component {
             'getExploreState',
             'handleGetExploreMore',
             'handleChangeSortMode',
+            'handleToggleRemoveButton',
             'getBubble'
         ]);
 
         this.state = this.getExploreState();
         this.state.loaded = [];
         this.state.offset = 0;
+        this.state.showRemoveButton = false;
     }
     componentDidMount () {
         this.handleGetExploreMore();
@@ -101,6 +103,11 @@ class Explore extends React.Component {
                 `${window.location.origin}/explore/${this.state.itemType}/${this.state.category}/${value}`;
         }
     }
+
+    handleToggleRemoveButton (e) {
+        this.setState({showRemoveButton: e.target.checked});
+    }
+
     getBubble (type) {
         const classes = classNames({
             active: (this.state.category === type)
@@ -215,6 +222,16 @@ class Explore extends React.Component {
                             />
                         </Form>
                     </div>
+                    <div className="sort-controls">
+                        <label>
+                            <span>Removal mode: </span>
+                            <input
+                                type="checkbox"
+                                checked={this.state.showRemoveButton}
+                                onChange={this.handleToggleRemoveButton}
+                            />
+                        </label>
+                    </div>
                     <div
                         id="projectBox"
                         key="projectBox"
@@ -227,6 +244,8 @@ class Explore extends React.Component {
                             showFavorites={false}
                             showLoves={false}
                             showViews={false}
+                            showRemoveButton={this.state.showRemoveButton}
+                            onRemove={(item) => { console.log(item) }}
                         />
                         <Button
                             onClick={this.handleGetExploreMore}

--- a/src/views/search/search.jsx
+++ b/src/views/search/search.jsx
@@ -91,7 +91,7 @@ class Search extends React.Component {
         this.props.dispatch(navigationActions.setSearchTerm(term));
     }
     componentDidUpdate (prevProps) {
-        const sessionLoaded =  this.props.session.status === sessionActions.Status.FETCHED;
+        const sessionLoaded = this.props.session.status === sessionActions.Status.FETCHED;
         const wasSessionLoaded = prevProps.session.status === sessionActions.Status.FETCHED;
 
         const becameAuthenticated = !wasSessionLoaded && sessionLoaded;
@@ -141,12 +141,12 @@ class Search extends React.Component {
             queryString += `&q=${termText}`;
         }
         
-        const isAdmin = this.props.session?.session?.permissions?.admin
-        const token = this.props.session?.session?.user?.token
+        const isAdmin = this.props.session?.session?.permissions?.admin;
+        const token = this.props.session?.session?.user?.token;
 
         api({
             uri: `${isAdmin ? '/admin' : ''}/search/${this.state.tab}?${queryString}`,
-            ...(isAdmin && token ? { authentication: token } : {})
+            ...(isAdmin && token ? {authentication: token} : {})
         }, (err, body) => {
             const loadedSoFar = this.state.loaded;
             Array.prototype.push.apply(loadedSoFar, body);
@@ -297,7 +297,7 @@ Search.propTypes = {
     intl: intlShape,
     searchTerm: PropTypes.string,
     session: PropTypes.object,
-    isTotallyNormal: PropTypes.bool, // eslint-disable-line react/no-unused-prop-types
+    isTotallyNormal: PropTypes.bool // eslint-disable-line react/no-unused-prop-types
 };
 
 const mapStateToProps = state => ({

--- a/src/views/search/search.jsx
+++ b/src/views/search/search.jsx
@@ -16,6 +16,7 @@ import TitleBanner from '../../components/title-banner/title-banner.jsx';
 import Tabs from '../../components/tabs/tabs.jsx';
 
 import {selectIsTotallyNormal} from '../../redux/session';
+import sessionActions from '../../redux/session.js';
 
 import Page from '../../components/page/www/page.jsx';
 import render from '../../lib/render.jsx';
@@ -90,7 +91,13 @@ class Search extends React.Component {
         this.props.dispatch(navigationActions.setSearchTerm(term));
     }
     componentDidUpdate (prevProps) {
-        if (this.props.searchTerm !== prevProps.searchTerm) {
+        const sessionLoaded =  this.props.session.status === sessionActions.Status.FETCHED;
+        const wasSessionLoaded = prevProps.session.status === sessionActions.Status.FETCHED;
+
+        const becameAuthenticated = !wasSessionLoaded && sessionLoaded;
+        const searchChanged = this.props.searchTerm !== prevProps.searchTerm;
+
+        if (sessionLoaded && (searchChanged || becameAuthenticated)) {
             this.handleGetSearchMore();
         }
     }
@@ -133,9 +140,13 @@ class Search extends React.Component {
         if (termText) {
             queryString += `&q=${termText}`;
         }
+        
+        const isAdmin = this.props.session?.session?.permissions?.admin
+        const token = this.props.session?.session?.user?.token
 
         api({
-            uri: `/search/${this.state.tab}?${queryString}`
+            uri: `${isAdmin ? '/admin' : ''}/search/${this.state.tab}?${queryString}`,
+            ...(isAdmin && token ? { authentication: token } : {})
         }, (err, body) => {
             const loadedSoFar = this.state.loaded;
             Array.prototype.push.apply(loadedSoFar, body);
@@ -284,12 +295,14 @@ class Search extends React.Component {
 Search.propTypes = {
     dispatch: PropTypes.func,
     intl: intlShape,
+    searchTerm: PropTypes.string,
+    session: PropTypes.object,
     isTotallyNormal: PropTypes.bool, // eslint-disable-line react/no-unused-prop-types
-    searchTerm: PropTypes.string
 };
 
 const mapStateToProps = state => ({
     searchTerm: state.navigation.searchTerm,
+    session: state.session,
     isTotallyNormal: selectIsTotallyNormal(state)
 });
 


### PR DESCRIPTION
### Resolves:

Work related to POD-251. Depends on https://github.com/scratchfoundation/scratch-api/pull/1891

### Changes:

* Searches now wait for session data to be ready
* If the signed in user is an admin, switch to the /admin/search/ endpoint
* Send along token in these cases

* This should have no impact on caching for regular user queries, as we're only sending the token if the user is an admin.

### Test Coverage:

Need to test:
* Admin users can search (and the new endpoint is used)
* Logged in users can still search
* Logged out users can still search
* ?