### PR TITLE
Make the unread message count background color be the color in the messages page.

### DIFF
--- a/src/components/navigation/www/navigation.scss
+++ b/src/components/navigation/www/navigation.scss
@@ -148,7 +148,7 @@
                 top: .5rem;
                 right: .25rem;
                 border-radius: 1rem;
-                background-color: $ui-orange;
+                background-color: #c40;
                 padding: 0 .25rem;
                 text-indent: 0;
                 line-height: 1rem;


### PR DESCRIPTION

### Resolves:

[GitHub Issue
](https://github.com/scratchfoundation/scratch-www/issues/9671)
### Changes:

This pull requests changes the background color from the UI orange to #c40.

### Test Coverage:

<img width="53" height="51" alt="Screenshot 2025-08-04 7 50 50 PM" src="https://github.com/user-attachments/assets/934af5c6-f586-4344-86f6-08e9b6655a35" />