### PR TITLE
Make "Add Projects" & "Invite Curators" black and some margin.

### DIFF
--- a/src/views/studio/studio.scss
+++ b/src/views/studio/studio.scss
@@ -410,7 +410,8 @@ $radius: 8px;
     margin-top: 20px;
 
     h3 {
-        color: $ui-purple-dark;
+        color: hsl(225deg 15.12% 28.16%);
+        margin: 10px 2px;
     }
 
     .studio-adder-row {


### PR DESCRIPTION
### Resolves:

[Issue](https://github.com/scratchfoundation/scratch-www/issues/9684)

### Changes:

Changed "Add Projects" & "Invite Curators" from purple to black and added some margin.

### Test Coverage:

<img width="947" height="185" alt="Screenshot 2025-08-04 8 57 59 PM" src="https://github.com/user-attachments/assets/96361d60-6b0f-40f2-859e-a38bda48858e" />
<img width="932" height="208" alt="Screenshot 2025-08-04 8 57 46 PM" src="https://github.com/user-attachments/assets/b5ceac6e-d9f6-4fb1-a965-5a368ba70b86" />
