### PR TITLE
Remove "today" from studio mail.

### DIFF
--- a/src/views/messages/l10n.json
+++ b/src/views/messages/l10n.json
@@ -25,7 +25,7 @@
     "messages.theRemixLinkText": "the remix",
     "messages.scratcherInvite": "You are invited to become a Scratcher! {learnMore}!",
     "messages.scratchTeamTitle": "Messages from the Scratch Team",
-    "messages.studioActivityText": "There was new activity in {studioLink} today",
+    "messages.studioActivityText": "There was new activity in {studioLink}",
     "messages.studioCommentReply": "{profileLink} replied to your comment in {commentLink}",
     "messages.userJoinText": "Welcome to Scratch! After you make projects and comments, you'll get messages about them here. Go {exploreLink} or {makeProjectLink}.",
     "messages.userJoinMakeProject": "make a project",


### PR DESCRIPTION
### Resolves:

[Issue](https://github.com/scratchfoundation/scratch-www/issues/9690)

### Changes:

Removes "today" from studio mail.

### Test Coverage:

<img width="1017" height="93" alt="Screenshot 2025-08-06 10 45 29 AM" src="https://github.com/user-attachments/assets/d8353075-2c44-4a25-91d1-5e13b449d689" />