### PR TITLE
fix: some correct inconstant coloring on the "Join" page 

### DIFF
--- a/src/components/registration/steps.scss
+++ b/src/components/registration/steps.scss
@@ -87,6 +87,11 @@
         .validation-info {
             top:auto;
             left:auto;
+            background-color: $ui-red-dark;
+
+         &::before {
+            background-color: $ui-red-dark;
+            }
         }
         > .description.wide { 
             margin: 0 -3.2rem 2rem -3.2rem;
@@ -107,7 +112,7 @@
 
             &:focus {
                 transition: all .5s ease;
-                border: 1px solid $ui-blue;
+                border: 1px solid $ui-purple;
             }
         }
 
@@ -167,7 +172,7 @@
 
             &.has-error {
                 .textarea {
-                    border: 1px solid $ui-orange;
+                    border: 1px solid $ui-red;
                 }
             }
         }


### PR DESCRIPTION
### Resolves:

[Fix: Issue](https://github.com/scratchfoundation/scratch-www/issues/7758)

### Changes:

Some tooltips like "Don't share your real name" wasn't `$ui-red-dark`.

### Test Coverage:

<img width="850" height="159" alt="Screenshot 2025-08-15 9 15 10 PM" src="https://github.com/user-attachments/assets/4c7135d0-47f3-478d-b9a8-801db7c199d6" />
<img width="797" height="236" alt="Screenshot 2025-08-15 9 15 02 PM" src="https://github.com/user-attachments/assets/876d54ab-1df8-486a-983b-2d1588b87808" />
