### PR TITLE
chore: add type annotations in fastly-extended.js

### DIFF
--- a/bin/configure-fastly.js
+++ b/bin/configure-fastly.js
@@ -28,9 +28,11 @@ const extraAppRoutes = [
 const routeJsonPreProcessed = routeJson.map(
     route => {
         if (route.redirect) {
-            process.stdout.write(`Updating: ${route.redirect} to `);
-            route.redirect = route.redirect.replace('RADISH_URL', RADISH_URL);
-            process.stdout.write(`${route.redirect}\n`);
+            const newRedirect = route.redirect.replace('RADISH_URL', RADISH_URL);
+            if (newRedirect !== route.redirect) {
+                console.log(`Updating: ${route.redirect} to ${newRedirect}`);
+                route.redirect = newRedirect;
+            }
         }
         return route;
     }

--- a/bin/configure-fastly.js
+++ b/bin/configure-fastly.js
@@ -42,7 +42,7 @@ async.auto({
             // Validate latest version before continuing
             if (response.active || response.locked) {
                 fastly.cloneVersion(response.number, (e, resp) => {
-                    if (e) return cb(`Failed to clone latest version: ${e}`);
+                    if (e) return cb(new Error('Failed to clone latest version', {cause: e}));
                     cb(null, resp.number);
                 });
             } else {
@@ -278,14 +278,14 @@ async.auto({
         });
     }]
 }, (err, results) => {
-    if (err) throw new Error(err);
+    if (err) throw err;
     if (process.env.FASTLY_ACTIVATE_CHANGES) {
         fastly.activateVersion(results.version, (e, resp) => {
-            if (e) throw new Error(e);
+            if (e) throw e;
             process.stdout.write(`Successfully configured and activated version ${resp.number}\n`);
             // purge static-assets using surrogate key
             fastly.purgeKey(FASTLY_SERVICE_ID, 'static-assets', error => {
-                if (error) throw new Error(error);
+                if (error) throw error;
                 process.stdout.write('Purged static assets.\n');
             });
         });

--- a/bin/configure-fastly.js
+++ b/bin/configure-fastly.js
@@ -90,6 +90,12 @@ async.auto({
             redirectRoute => fastlyConfig.getConditionNameForRoute(redirectRoute, 'request')
         );
 
+        // These two don't come from the `routes` file.
+        // They're hard-coded as later steps in this configuration script.
+        keepResponses.push('redirects/?tip_bar=');
+        keepResponses.push('redirects/projects/embed');
+
+        // Keep some statistics
         const keepReasons = {};
         const incrementKeepReason = key => {
             keepReasons[key] = (keepReasons[key] || 0) + 1;
@@ -139,8 +145,7 @@ async.auto({
         // If you don't care about that, you could just use `filter()`.
         const [remove, keep] = partition(allResponseObjects, shouldRemove);
         console.log(`Found ${remove.length} response objects to remove and ${keep.length} to keep`);
-        console.log('Reasons for keeping response objects:');
-        console.dir(keepReasons);
+        console.log('Reasons for keeping response objects:', keepReasons);
         async.each(remove, (responseObject, cb2) => {
             console.log(`Removing response object with name "${responseObject.name}"`);
             fastly.deleteResponseObject(results.version, responseObject.name, cb2);

--- a/bin/configure-fastly.js
+++ b/bin/configure-fastly.js
@@ -5,11 +5,13 @@ const languages = require('scratch-l10n').default;
 
 const routeJson = require('../src/routes.json');
 
+const FASTLY_API_KEY = process.env.FASTLY_API_KEY || '';
 const FASTLY_SERVICE_ID = process.env.FASTLY_SERVICE_ID || '';
 const S3_BUCKET_NAME = process.env.S3_BUCKET_NAME || '';
 const RADISH_URL = process.env.RADISH_URL || '';
 
-const fastly = require('./lib/fastly-extended')(process.env.FASTLY_API_KEY, FASTLY_SERVICE_ID);
+const FastlyExtended = require('./lib/fastly-extended');
+const fastly = new FastlyExtended(FASTLY_API_KEY, FASTLY_SERVICE_ID);
 
 const extraAppRoutes = [
     // Homepage with querystring.

--- a/bin/configure-fastly.js
+++ b/bin/configure-fastly.js
@@ -139,7 +139,13 @@ async.auto({
         console.log(`Found ${remove.length} response objects to remove and ${keep.length} to keep`);
         console.log('Reasons for keeping response objects:');
         console.dir(keepReasons);
-        cb();
+        async.each(remove, (responseObject, cb2) => {
+            console.log(`Removing response object with name "${responseObject.name}"`);
+            fastly.deleteResponseObject(results.version, responseObject.name, cb2);
+        }, err => {
+            if (err) return cb(err);
+            cb(); // success
+        });
     }],
     recvCustomVCL: ['version', function (results, cb) {
         // For all the routes in routes.json, construct a varnish-style regex that matches

--- a/bin/lib/fastly-extended.js
+++ b/bin/lib/fastly-extended.js
@@ -267,6 +267,21 @@ class FastlyExtended {
     }
 
     /**
+     * Delete a Fastly response object
+     * @param {number} version - The version number of the Fastly service
+     * @param {string} name - The name of the response object to delete
+     * @param {FastlyCallback<void>} cb - Completion callback
+     * @returns {void}
+     */
+    deleteResponseObject (version, name, cb) {
+        if (!this.serviceId) {
+            return cb(new Error('Failed to delete response object. No serviceId configured.'));
+        }
+        const url = `${this.getFastlyAPIPrefix(this.serviceId, version)}/response_object/${encodeURIComponent(name)}`;
+        this.request('DELETE', url, cb);
+    }
+
+    /**
      * cloneVersion: Clone a version to create a new version
      *
      * @param {number} version - Version to clone

--- a/bin/lib/fastly-extended.js
+++ b/bin/lib/fastly-extended.js
@@ -1,39 +1,104 @@
 const Fastly = require('fastly');
 
+/**
+ * The custom `Error` object reported by the Fastly library's implementation of `request`
+ * includes an HTTP status code when an HTTP failure occurs.
+ * @typedef {Error & { statusCode: number }} FastlyRequestError
+ */
+
+/**
+ * Node-style callback reporting an error
+ * @callback FastlyErrorCallback
+ * @param {!string} err - Error object or null if no error occurred. TODO: this should be `Error` in the future.
+ * @param {unknown} [ignored] - The result of the operation, ignored due to error.
+ * @returns {void}
+ */
+
+/**
+ * Node-style callback reporting a successful result
+ * @template T
+ * @callback FastlyResultCallback
+ * @param {null|undefined} ignored - The error object, which should be null or undefined if no error occurred.
+ * @param {T} result - The result of the operation.
+ * @returns {void}
+ */
+
+/**
+ * Node-style callback for Fastly requests
+ * @template T
+ * @typedef {FastlyErrorCallback & FastlyResultCallback<T>} FastlyCallback
+ */
+
+/* ******** Fastly data model ******** */
+// Many of these objects have more fields than shown here.
+// See here for details: https://www.fastly.com/documentation/reference/api/
+
+/**
+ * @typedef {Object} FastlyServiceVersion
+ * @property {number} number Version number
+ * @property {boolean} active Whether the version is active
+ * @property {boolean} locked Whether the version is locked
+ */
+
+/**
+ * @typedef {Object} FastlyVclCondition
+ * @property {string} name Condition name
+ * @property {string} statement Condition VCL statement
+ */
+
+/**
+ * @typedef {'set' | 'append' | 'delete' | 'regex' | 'regex_repeat'} FastlyHeaderAction
+ */
+
+/**
+ * @typedef {Object} FastlyVclHeader
+ * @property {string} name Header name
+ * @property {FastlyHeaderAction} action Header action
+ */
+
+/**
+ * @typedef {Object} FastlyVclLintReport
+ * @property {Array<string>} errors List of linting errors found
+ * @property {Array<string>} warnings List of linting warnings found
+ */
+
+/**
+ * @typedef {Object} FastlyVclResponseObject
+ * @property {string} name Response object name
+ * @property {string} request_condition Request condition name
+ * @property {number} status HTTP status code
+ * @property {string} response Response body
+ */
+
 /*
  * Fastly library extended to allow configuration for a particular service
  * and some helper methods.
- *
- * @param {string} API key
- * @param {string} Service id
  */
-module.exports = function (apiKey, serviceId) {
+module.exports = function (/** @type {string} */ apiKey, /** @type {string} */ serviceId) {
     const fastly = Fastly(apiKey);
     fastly.serviceId = serviceId;
 
-    /*
+    /**
      * Helper method for constructing Fastly API urls
-     *
-     * @param {string} Service id
-     * @param {number} Version
-     *
-     * @return {string}
+     * @param {string} servId - Fastly service ID
+     * @param {number} version - Fastly service version
+     * @return {string} Fastly API url prefix
      */
     fastly.getFastlyAPIPrefix = function (servId, version) {
         return `/service/${encodeURIComponent(servId)}/version/${version}`;
     };
 
-    /*
+    /**
      * getLatestActiveVersion: Get the most recent version for the configured service
-     *
-     * @param {callback} Callback with signature *err, latestVersion)
+     * @param {FastlyCallback<FastlyServiceVersion?>} cb - Callback for the latest active version
+     * @returns {void}
      */
     fastly.getLatestActiveVersion = function (cb) {
         if (!this.serviceId) {
             return cb('Failed to get latest version. No serviceId configured');
         }
         const url = `/service/${encodeURIComponent(this.serviceId)}/version`;
-        this.request('GET', url, (err, versions) => {
+        this.request('GET', url, (/** @type {Error} */ err, /** @type {FastlyServiceVersion[]} */ versions) => {
             if (err) {
                 return cb(`Failed to fetch versions: ${err}`);
             }
@@ -45,18 +110,19 @@ module.exports = function (apiKey, serviceId) {
                 if (!latestActiveSoFar || !latestActiveSoFar.active) return cur;
                 // when both are active, prefer whichever has a higher version number.
                 return (cur.number > latestActiveSoFar.number) ? cur : latestActiveSoFar;
-            }, null);
+            }, /** @type {FastlyServiceVersion?} */ (null));
             return cb(null, latestVersion);
         });
     };
 
-    /*
+    /**
      * setCondition: Upsert a Fastly condition entry
      * Attempts to PUT and POSTs if the PUT request is a 404
      *
-     * @param {number} Version number
-     * @param {object} Condition object sent to the API
-     * @param {callback} Callback for fastly.request
+     * @param {number} version - Fastly service's version number
+     * @param {FastlyVclCondition} condition - Condition object sent to the API
+     * @param {FastlyCallback<FastlyVclCondition>} cb - Callback returning the created or updated object on success
+     * @returns {void}
      */
     fastly.setCondition = function (version, condition, cb) {
         if (!this.serviceId) {
@@ -65,30 +131,35 @@ module.exports = function (apiKey, serviceId) {
         const name = condition.name;
         const putUrl = `${this.getFastlyAPIPrefix(this.serviceId, version)}/condition/${encodeURIComponent(name)}`;
         const postUrl = `${this.getFastlyAPIPrefix(this.serviceId, version)}/condition`;
-        return this.request('PUT', putUrl, condition, (err, response) => {
-            if (err && err.statusCode === 404) {
-                this.request('POST', postUrl, condition, (e, resp) => {
-                    if (e) {
-                        return cb(`Failed while inserting condition "${condition.statement}": ${e}`);
-                    }
-                    return cb(null, resp);
-                });
-                return;
+        return this.request('PUT', putUrl, condition,
+            (/** @type {FastlyRequestError} */ err, /** @type {FastlyVclCondition} */ response) => {
+                if (err && err.statusCode === 404) {
+                    this.request('POST', postUrl, condition,
+                        (/** @type {FastlyRequestError} */ e, /** @type {FastlyVclCondition} */ resp) => {
+                            if (e) {
+                                return cb(`Failed while inserting condition "${condition.statement}": ${e}`);
+                            }
+                            return cb(null, resp);
+                        }
+                    );
+                    return;
+                }
+                if (err) {
+                    return cb(`Failed to update condition "${condition.statement}": ${err}`);
+                }
+                return cb(null, response);
             }
-            if (err) {
-                return cb(`Failed to update condition "${condition.statement}": ${err}`);
-            }
-            return cb(null, response);
-        });
+        );
     };
 
-    /*
+    /**
      * setFastlyHeader: Upsert a Fastly header entry
      * Attempts to PUT and POSTs if the PUT request is a 404
      *
-     * @param {number} Version number
-     * @param {object} Header object sent to the API
-     * @param {callback} Callback for fastly.request
+     * @param {number} version - Fastly service's version number
+     * @param {FastlyVclHeader} header - Header object sent to the API
+     * @param {FastlyCallback<FastlyVclHeader>} cb - Callback returning the created or updated object on success
+     * @returns {void}
      */
     fastly.setFastlyHeader = function (version, header, cb) {
         if (!this.serviceId) {
@@ -97,30 +168,35 @@ module.exports = function (apiKey, serviceId) {
         const name = header.name;
         const putUrl = `${this.getFastlyAPIPrefix(this.serviceId, version)}/header/${encodeURIComponent(name)}`;
         const postUrl = `${this.getFastlyAPIPrefix(this.serviceId, version)}/header`;
-        return this.request('PUT', putUrl, header, (err, response) => {
-            if (err && err.statusCode === 404) {
-                this.request('POST', postUrl, header, (e, resp) => {
-                    if (e) {
-                        return cb(`Failed to insert header: ${e}`);
-                    }
-                    return cb(null, resp);
-                });
-                return;
+        return this.request('PUT', putUrl, header,
+            (/** @type {FastlyRequestError} */ err, /** @type {FastlyVclHeader} */ response) => {
+                if (err && err.statusCode === 404) {
+                    this.request('POST', postUrl, header,
+                        (/** @type {FastlyRequestError} */ e, /** @type {FastlyVclHeader} */ resp) => {
+                            if (e) {
+                                return cb(`Failed to insert header: ${e}`);
+                            }
+                            return cb(null, resp);
+                        }
+                    );
+                    return;
+                }
+                if (err) {
+                    return cb(`Failed to update header: ${err}`);
+                }
+                return cb(null, response);
             }
-            if (err) {
-                return cb(`Failed to update header: ${err}`);
-            }
-            return cb(null, response);
-        });
+        );
     };
 
-    /*
+    /**
      * setResponseObject: Upsert a Fastly response object
      * Attempts to PUT and POSTs if the PUT request is a 404
      *
-     * @param {number} Version number
-     * @param {object} Response object sent to the API
-     * @param {callback} Callback for fastly.request
+     * @param {number} version - Fastly service's version number
+     * @param {object} responseObj - Response object sent to the API
+     * @param {FastlyCallback<FastlyVclResponseObject>} cb - Callback returning the created or updated object on success
+     * @returns {void}
      */
     fastly.setResponseObject = function (version, responseObj, cb) {
         if (!this.serviceId) {
@@ -130,28 +206,33 @@ module.exports = function (apiKey, serviceId) {
         const putUrl =
             `${this.getFastlyAPIPrefix(this.serviceId, version)}/response_object/${encodeURIComponent(name)}`;
         const postUrl = `${this.getFastlyAPIPrefix(this.serviceId, version)}/response_object`;
-        return this.request('PUT', putUrl, responseObj, (err, response) => {
-            if (err && err.statusCode === 404) {
-                this.request('POST', postUrl, responseObj, (e, resp) => {
-                    if (e) {
-                        return cb(`Failed to insert response object: ${e}`);
-                    }
-                    return cb(null, resp);
-                });
-                return;
+        return this.request('PUT', putUrl, responseObj,
+            (/** @type {FastlyRequestError} */ err, /** @type {FastlyVclResponseObject} */ response) => {
+                if (err && err.statusCode === 404) {
+                    this.request('POST', postUrl, responseObj,
+                        (/** @type {FastlyRequestError} */ e, /** @type {FastlyVclResponseObject} */ resp) => {
+                            if (e) {
+                                return cb(`Failed to insert response object: ${e}`);
+                            }
+                            return cb(null, resp);
+                        }
+                    );
+                    return;
+                }
+                if (err) {
+                    return cb(`Failed to update response object: ${err}`);
+                }
+                return cb(null, response);
             }
-            if (err) {
-                return cb(`Failed to update response object: ${err}`);
-            }
-            return cb(null, response);
-        });
+        );
     };
 
-    /*
+    /**
      * cloneVersion: Clone a version to create a new version
      *
-     * @param {number} Version to clone
-     * @param {callback} Callback for fastly.request
+     * @param {number} version - Version to clone
+     * @param {FastlyCallback<FastlyServiceVersion>} cb - Callback returning the cloned version on success
+     * @returns {void}
      */
     fastly.cloneVersion = function (version, cb) {
         if (!this.serviceId) return cb('Failed to clone version. No serviceId configured.');
@@ -159,11 +240,12 @@ module.exports = function (apiKey, serviceId) {
         this.request('PUT', url, cb);
     };
 
-    /*
+    /**
      * activateVersion: Activate a version
      *
-     * @param {number} Version number
-     * @param {callback} Callback for fastly.request
+     * @param {number} version - Version to activate
+     * @param {FastlyCallback<FastlyServiceVersion>} cb - Callback returning the activated version on success
+     * @returns {void}
      */
     fastly.activateVersion = function (version, cb) {
         if (!this.serviceId) return cb('Failed to activate version. No serviceId configured.');
@@ -171,14 +253,15 @@ module.exports = function (apiKey, serviceId) {
         this.request('PUT', url, cb);
     };
 
-    /*
+    /**
      * Upsert a custom vcl file. Attempts a PUT, and falls back
      * to POST if not there already.
      *
-     * @param {number}   version current version number for fastly service
-     * @param {string}   name    name of the custom vcl file to be upserted
-     * @param {string}   vcl     stringified custom vcl to be uploaded
-     * @param {Function} cb      function that takes in two args: err, response
+     * @param {number}   version - Target version number for Fastly service
+     * @param {string}   name    - Name of the custom vcl file to be upserted
+     * @param {string}   vcl     - Stringified custom vcl to be uploaded
+     * @param {FastlyCallback<FastlyVclLintReport>} cb - Callback returning the lint report on success
+     * @returns {void}
      */
     fastly.setCustomVCL = function (version, name, vcl, cb) {
         if (!this.serviceId) {
@@ -188,22 +271,26 @@ module.exports = function (apiKey, serviceId) {
         const url = `${this.getFastlyAPIPrefix(this.serviceId, version)}/vcl/${name}`;
         const postUrl = `${this.getFastlyAPIPrefix(this.serviceId, version)}/vcl`;
         const content = {content: vcl};
-        return this.request('PUT', url, content, (err, response) => {
-            if (err && err.statusCode === 404) {
-                content.name = name;
-                this.request('POST', postUrl, content, (e, resp) => {
-                    if (e) {
-                        return cb(`Failed while adding custom vcl "${name}": ${e}`);
-                    }
-                    return cb(null, resp);
-                });
-                return;
+        return this.request('PUT', url, content,
+            (/** @type {FastlyRequestError} */ err, /** @type {FastlyVclLintReport} */ response) => {
+                if (err && err.statusCode === 404) {
+                    content.name = name;
+                    this.request('POST', postUrl, content,
+                        (/** @type {FastlyRequestError} */ e, /** @type {FastlyVclLintReport} */ resp) => {
+                            if (e) {
+                                return cb(`Failed while adding custom vcl "${name}": ${e}`);
+                            }
+                            return cb(null, resp);
+                        }
+                    );
+                    return;
+                }
+                if (err) {
+                    return cb(`Failed to update custom vcl "${name}": ${err}`);
+                }
+                return cb(null, response);
             }
-            if (err) {
-                return cb(`Failed to update custom vcl "${name}": ${err}`);
-            }
-            return cb(null, response);
-        });
+        );
     };
 
     return fastly;

--- a/bin/lib/fastly-extended.js
+++ b/bin/lib/fastly-extended.js
@@ -215,6 +215,20 @@ class FastlyExtended {
     }
 
     /**
+     * Get response objects for a specific version
+     * @param {number} version - The version number of the Fastly service
+     * @param {FastlyCallback<FastlyVclResponseObject[]>} cb - Callback listing response objects on success
+     * @returns {void}
+     */
+    getResponseObjects (version, cb) {
+        if (!this.serviceId) {
+            return cb(new Error('Failed to get response objects. No serviceId configured.'));
+        }
+        const url = `${this.getFastlyAPIPrefix(this.serviceId, version)}/response_object`;
+        this.request('GET', url, cb);
+    }
+
+    /**
      * setResponseObject: Upsert a Fastly response object
      * Attempts to PUT and POSTs if the PUT request is a 404
      *

--- a/test/unit/lib/fastly-extended.test.js
+++ b/test/unit/lib/fastly-extended.test.js
@@ -2,9 +2,10 @@ describe('fastly library', () => {
     let mockedFastlyRequest = {};
 
     jest.mock('fastly', () => (() => ({
-        request: mockedFastlyRequest
+        request: mockedFastlyRequest,
+        purgeKey: jest.fn()
     })));
-    const fastlyExtended = require('../../../bin/lib/fastly-extended'); // eslint-disable-line global-require
+    const FastlyExtended = require('../../../bin/lib/fastly-extended'); // eslint-disable-line global-require
 
     test('getLatestActiveVersion returns largest active VCL number, ' +
         'when called with VCLs in sequential order', done => {
@@ -28,7 +29,7 @@ describe('fastly library', () => {
                 }
             ]);
         });
-        const fastlyInstance = fastlyExtended('api_key', 'service_id');
+        const fastlyInstance = new FastlyExtended('api_key', 'service_id');
 
         fastlyInstance.getLatestActiveVersion((err, response) => {
             expect(err).toBe(null);
@@ -64,7 +65,7 @@ describe('fastly library', () => {
                 }
             ]);
         });
-        const fastlyInstance = fastlyExtended('api_key', 'service_id');
+        const fastlyInstance = new FastlyExtended('api_key', 'service_id');
 
         fastlyInstance.getLatestActiveVersion((err, response) => {
             expect(err).toBe(null);
@@ -100,7 +101,7 @@ describe('fastly library', () => {
                 }
             ]);
         });
-        const fastlyInstance = fastlyExtended('api_key', 'service_id');
+        const fastlyInstance = new FastlyExtended('api_key', 'service_id');
 
         fastlyInstance.getLatestActiveVersion((err, response) => {
             expect(err).toBe(null);
@@ -122,7 +123,7 @@ describe('fastly library', () => {
                 }
             ]);
         });
-        const fastlyInstance = fastlyExtended('api_key', 'service_id');
+        const fastlyInstance = new FastlyExtended('api_key', 'service_id');
 
         fastlyInstance.getLatestActiveVersion((err, response) => {
             expect(err).toBe(null);
@@ -146,7 +147,7 @@ describe('fastly library', () => {
                 }
             ]);
         });
-        const fastlyInstance = fastlyExtended('api_key', 'service_id');
+        const fastlyInstance = new FastlyExtended('api_key', 'service_id');
 
         fastlyInstance.getLatestActiveVersion((err, response) => {
             expect(err).toBe(null);


### PR DESCRIPTION
### Resolves:

Supports POD-277

### Changes:

Primary change: remove obsolete response objects from Fastly configuration before attempting to update or add any. This helps avoid exceeding the ~100-count limit.

Supporting changes:

- Type annotations, especially in `fastly-extended.js`, so I could tell what I was doing.
- Converted `fastly-extended.js` into a class so that the type annotations would work.
- Use `Error` instances for error reporting in `configure-fastly.js`, as opposed to using `string`.
  - Using `string` was incorrect as it violates the `async` library's expectations
  - It was also inconsistent: when reporting an error to the `async` library, we were sometimes passing a string and sometimes passing the output of the `fastly` library's `request` call, which uses `Error`.
- Reduced log output during redirect preprocessing

### Test Coverage:

Existing tests updated
