### PR TITLE
fix: use more robust css selectors and add additional property to pre…

### DIFF
--- a/src/views/preview/project-view.scss
+++ b/src/views/preview/project-view.scss
@@ -9,8 +9,9 @@
     pointer-events: auto !important;
 }
 
-.tooltip-set-thumbnail ~ .driver-overlay {
+.driver-active:has(.tooltip-set-thumbnail) > .driver-overlay {
     z-index: -1 !important;
+    visibility: hidden;
 }
 
 .driver-popover.tooltip-set-thumbnail {


### PR DESCRIPTION
…vent tooltip overlay from breaking screen interactions

### Resolves:

https://scratchfoundation.atlassian.net/browse/UEPR-323

### Changes:

* Make sure overlay position in DOM doesn't affect whether overlay z-index is applied
* Also add visibility:hidden, in case `z-index` isn't successfully applied / doesn't work on specific browsers