### PR TITLE
[UEPR-332] Align copy for parent confirmation prompts

### DIFF
--- a/src/l10n.json
+++ b/src/l10n.json
@@ -390,6 +390,7 @@
     "comments.isIPMuted": "Sorry, the Scratch Team had to prevent your network from sharing comments or projects because it was used to break our community guidelines too many times. You can still share comments and projects from another network. If you'd like to appeal this block, you can contact appeals@scratch.mit.edu and reference Case Number {appealId}.",
     "comments.isTooLong": "That comment is too long! Please find a way to shorten your text.",
     "comments.isNotPermitted": "Sorry, you need to confirm your email address before commenting.",
+    "comments.isNotPermittedByParent": "Sorry, a parent needs to confirm your account before you can comment.",
     "comments.error": "Oops! Something went wrong posting your comment",
     "comments.posting": "Posting...",
     "comments.post": "Post",

--- a/src/views/preview/presentation.jsx
+++ b/src/views/preview/presentation.jsx
@@ -248,6 +248,7 @@ const PreviewPresentation = ({
             {showEmailConfirmationModal && <EmailConfirmationModal
                 isOpen
                 onRequestClose={onCloseEmailConfirmationModal}
+                userUsesParentEmail={userUsesParentEmail}
             />}
             {showAdminPanel && (
                 <AdminPanel

--- a/src/views/studio/l10n.json
+++ b/src/views/studio/l10n.json
@@ -19,6 +19,7 @@
     "studio.updateErrors.thumbnailInvalid": "Upload a valid image. The file you uploaded was either not an image or a corrupted image.",
 
     "studio.followErrors.confirmEmail": "Please confirm your email address first",
+    "studio.followErrors.confirmAccount": "A parent needs to confirm your account first",
     "studio.followErrors.generic": "Something went wrong following the studio",
 
     "studio.sectionLoadError.projectsHeadline": "Something went wrong loading projects",

--- a/src/views/studio/studio-follow.jsx
+++ b/src/views/studio/studio-follow.jsx
@@ -13,9 +13,12 @@ import {
 import classNames from 'classnames';
 import ValidationMessage from '../../components/forms/validation-message.jsx';
 
-const errorToMessageId = error => {
+const errorToMessageId = (error, userUsesParentEmail) => {
     switch (error) {
-    case Errors.PERMISSION: return 'studio.followErrors.confirmEmail';
+    case Errors.PERMISSION: return userUsesParentEmail ?
+        'studio.followErrors.confirmAccount' :
+        'studio.followErrors.confirmEmail';
+
     default: return 'studio.followErrors.generic';
     }
 };
@@ -25,8 +28,10 @@ const StudioFollow = ({
     isFollowing,
     isMutating,
     followingError,
-    handleFollow
+    handleFollow,
+    flags
 }) => {
+    const userUsesParentEmail = flags && flags.with_parent_email;
     const fieldClassName = classNames('button', 'studio-follow-button', {
         'mod-mutating': isMutating
     });
@@ -61,7 +66,7 @@ const StudioFollow = ({
             </button>
             {followingError && !hideValidationMessage && <ValidationMessage
                 mode="error"
-                message={<FormattedMessage id={errorToMessageId(followingError)} />}
+                message={<FormattedMessage id={errorToMessageId(followingError, userUsesParentEmail)} />}
             />}
         </div>
     );
@@ -72,15 +77,18 @@ StudioFollow.propTypes = {
     isFollowing: PropTypes.bool,
     isMutating: PropTypes.bool,
     followingError: PropTypes.string,
-    handleFollow: PropTypes.func
-};
+    handleFollow: PropTypes.func,
+    flags: PropTypes.shape({
+        with_parent_email: PropTypes.bool
+    })};
 
 export default connect(
     state => ({
         canFollow: selectCanFollowStudio(state),
         isMutating: selectIsMutatingFollowing(state),
         isFollowing: selectIsFollowing(state),
-        followingError: selectFollowingMutationError(state)
+        followingError: selectFollowingMutationError(state),
+        flags: state.session.session.flags
     }),
     {
         handleFollow: mutateFollowingStudio

--- a/src/views/studio/studio-follow.jsx
+++ b/src/views/studio/studio-follow.jsx
@@ -29,9 +29,8 @@ const StudioFollow = ({
     isMutating,
     followingError,
     handleFollow,
-    flags
+    withParentEmail
 }) => {
-    const userUsesParentEmail = flags && flags.with_parent_email;
     const fieldClassName = classNames('button', 'studio-follow-button', {
         'mod-mutating': isMutating
     });
@@ -66,7 +65,7 @@ const StudioFollow = ({
             </button>
             {followingError && !hideValidationMessage && <ValidationMessage
                 mode="error"
-                message={<FormattedMessage id={errorToMessageId(followingError, userUsesParentEmail)} />}
+                message={<FormattedMessage id={errorToMessageId(followingError, withParentEmail)} />}
             />}
         </div>
     );
@@ -78,9 +77,8 @@ StudioFollow.propTypes = {
     isMutating: PropTypes.bool,
     followingError: PropTypes.string,
     handleFollow: PropTypes.func,
-    flags: PropTypes.shape({
-        with_parent_email: PropTypes.bool
-    })};
+    withParentEmail: PropTypes.bool
+};
 
 export default connect(
     state => ({
@@ -88,7 +86,7 @@ export default connect(
         isMutating: selectIsMutatingFollowing(state),
         isFollowing: selectIsFollowing(state),
         followingError: selectFollowingMutationError(state),
-        flags: state.session.session.flags
+        withParentEmail: state.session.session.flags && state.session.session.flags.with_parent_email
     }),
     {
         handleFollow: mutateFollowingStudio


### PR DESCRIPTION
### Resolves:

[UEPR-332](https://scratchfoundation.atlassian.net/browse/UEPR-332)

### Changes:

- Pass flag for displaying the U16 modal copy when attempting to share a project
- Add different error message for unverified U16 accounts attempting to comment (depends on [scratchr2 changes](https://github.com/scratchfoundation/scratchr2/commit/12e40380083f2a591712477777633abbd1bfefa5))
- Update error message when an unverified U16 user attempts to follow a studio

### Test Coverage:

Attempting to share a project:
<img width="511" height="399" alt="image" src="https://github.com/user-attachments/assets/eb3bc964-0386-4b1d-919d-fbb5bf928bb4" />

Commenting:
<img width="878" height="39" alt="image" src="https://github.com/user-attachments/assets/b5e5cc88-2355-4cbf-a49b-558efcb73945" />

Following a studio:
<img width="603" height="142" alt="image" src="https://github.com/user-attachments/assets/f7d77776-9299-49d0-a5a1-240d3da3cd35" />


[UEPR-332]: https://scratchfoundation.atlassian.net/browse/UEPR-332?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ