### PR TITLE
Remove Greenkeeper badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 
 [![Build Status](https://travis-ci.org/LLK/scratch-www.svg)](https://travis-ci.org/LLK/scratch-www)
 [![Coverage Status](https://coveralls.io/repos/github/LLK/scratch-www/badge.svg?branch=develop)](https://coveralls.io/github/LLK/scratch-www?branch=develop)
-[![Greenkeeper badge](https://badges.greenkeeper.io/LLK/scratch-www.svg)](https://greenkeeper.io/)
 
 ## Overview
 


### PR DESCRIPTION
### Resolves:

#9787 

### Changes:

Removes the Greenkeeper badge since it doesn't work anymore

### Test Coverage:

<img width="513" height="170" alt="Screenshot 2025-09-18 alle 13 48 57" src="https://github.com/user-attachments/assets/bb3fafd4-8ac4-4633-8249-b173c708fe76" />

