### PR TITLE
keep banner up when parental permission is needed

### DIFF
--- a/src/components/dropdown-banner/email-confirmation/banner.jsx
+++ b/src/components/dropdown-banner/email-confirmation/banner.jsx
@@ -26,7 +26,7 @@ const EmailConfirmationBanner = ({onRequestDismiss, userUsesParentEmail}) => {
             <DropdownBanner
                 className="warning"
                 key="confirmedEmail"
-                onRequestDismiss={onRequestDismiss}
+                onRequestDismiss={userUsesParentEmail ? null : onRequestDismiss}
             >
                 <FormattedMessage
                     id={`${i18nPrefix}.confirm`}

--- a/test/unit/components/email-confirmation-banner.test.jsx
+++ b/test/unit/components/email-confirmation-banner.test.jsx
@@ -21,6 +21,28 @@ describe('EmailConfirmationBanner', () => {
         expect(container).toHaveTextContent('MockEmailConfirmationModal');
     });
 
+    test('Close button depends on userUsesParentEmail prop', () => {
+        const requestDismissMock = jest.fn();
+
+        const {container: containerWithParentEmail} = renderWithIntl(
+            <EmailConfirmationBanner
+                userUsesParentEmail
+                onRequestDismiss={requestDismissMock}
+            />
+        );
+
+        expect(containerWithParentEmail.querySelector('a.close')).toBeNull();
+
+        const {container: containerWithoutParentEmail} = renderWithIntl(
+            <EmailConfirmationBanner
+                userUsesParentEmail={false}
+                onRequestDismiss={requestDismissMock}
+            />
+        );
+
+        expect(containerWithoutParentEmail.querySelector('a.close')).not.toBeNull();
+    });
+
     test('Clicking X calls onRequestDismiss', () => {
 
         const requestDismissMock = jest.fn();


### PR DESCRIPTION
### Resolves:

- Resolves POD-315

### Changes:

The close button on the email confirmation banner only shows when email confirmation is optional

### Test Coverage:

Added a test to verify the close button appears/disappears as appropriate