### PR TITLE
fix: Rename Macedonia to North Macedonia in country data

### DIFF
--- a/src/lib/country-data.js
+++ b/src/lib/country-data.js
@@ -678,7 +678,7 @@ const countryInfo = module.exports.countryInfo = [
         code: 'nf'
     },
     {
-        name: 'Macedonia, The Former Yugoslav Republic of',
+        name: 'North Macedonia',
         display: 'North Macedonia',
         code: 'mk'
     },


### PR DESCRIPTION
### Resolves:

[issue](https://github.com/scratchfoundation/scratch-www/issues/10352)

### Changes:

Renames one country in `country-data.json` to `North Macedonia`.

### Test Coverage:

Should work?