### PR TITLE
refactor: migrate Fastly client from 1.2.1 to 15

### DIFF
--- a/bin/lib/fastly-extended.js
+++ b/bin/lib/fastly-extended.js
@@ -1,210 +1,116 @@
 const Fastly = require('fastly');
 
 /*
- * Fastly library extended to allow configuration for a particular service
- * and some helper methods.
+ * Fastly configuration helpers for a particular service, built on the official
+ * fastly-js client (v15+). Each method keeps the callback signature the callers
+ * rely on -- `(...args, cb)` invoking `cb(err, result)` -- so the client bump is
+ * isolated to this file.
  *
- * @param {string} API key
- * @param {string} Service id
+ * @param {string} apiKey    Fastly API token
+ * @param {string} serviceId Fastly service id
  */
-module.exports = function (apiKey, serviceId) {
-    const fastly = Fastly(apiKey);
-    fastly.serviceId = serviceId;
+module.exports = (apiKey, serviceId) => {
+    Fastly.ApiClient.instance.authenticate(apiKey);
 
-    /*
-     * Helper method for constructing Fastly API urls
-     *
-     * @param {string} Service id
-     * @param {number} Version
-     *
-     * @return {string}
-     */
-    fastly.getFastlyAPIPrefix = function (servId, version) {
-        return `/service/${encodeURIComponent(servId)}/version/${version}`;
+    const versionApi = new Fastly.VersionApi();
+    const conditionApi = new Fastly.ConditionApi();
+    const headerApi = new Fastly.HeaderApi();
+    const responseObjectApi = new Fastly.ResponseObjectApi();
+    const vclApi = new Fastly.VclApi();
+    const purgeApi = new Fastly.PurgeApi();
+
+    // Settle a promise into the (err, result) callback the callers expect.
+    const toCallback = (promise, cb) => promise.then(
+        result => cb(null, result),
+        err => cb(err)
+    );
+
+    // Update first, create on a 404. Mirrors the previous PUT-then-POST upsert.
+    const upsert = (update, create) => update().catch(err => {
+        if (err && err.status === 404) return create();
+        throw err;
+    });
+
+    const base = version => ({service_id: serviceId, version_id: version});
+
+    return {
+        // Most recent *active* version for the service (null if none active).
+        getLatestActiveVersion: cb => {
+            if (!serviceId) return cb('Failed to get latest version. No serviceId configured');
+            return toCallback(
+                versionApi.listServiceVersions({service_id: serviceId}).then(versions =>
+                    versions.reduce((latestActiveSoFar, cur) => {
+                        // if one of [latestActiveSoFar, cur] is active and the other isn't,
+                        // return whichever is active. If both are not active, return
+                        // latestActiveSoFar.
+                        if (!cur || !cur.active) return latestActiveSoFar;
+                        if (!latestActiveSoFar || !latestActiveSoFar.active) return cur;
+                        // when both are active, prefer whichever has a higher version number.
+                        return (cur.number > latestActiveSoFar.number) ? cur : latestActiveSoFar;
+                    }, null)
+                ),
+                cb
+            );
+        },
+
+        // Clone a version to create a new, editable version.
+        cloneVersion: (version, cb) => {
+            if (!serviceId) return cb('Failed to clone version. No serviceId configured.');
+            return toCallback(versionApi.cloneServiceVersion(base(version)), cb);
+        },
+
+        // Activate a version.
+        activateVersion: (version, cb) => {
+            if (!serviceId) return cb('Failed to activate version. No serviceId configured.');
+            return toCallback(versionApi.activateServiceVersion(base(version)), cb);
+        },
+
+        // Upsert a condition.
+        setCondition: (version, condition, cb) => {
+            if (!serviceId) return cb('Failed to set condition. No serviceId configured');
+            const fields = Object.assign(base(version), condition);
+            return toCallback(upsert(
+                () => conditionApi.updateCondition(Object.assign({condition_name: condition.name}, fields)),
+                () => conditionApi.createCondition(fields)
+            ), cb);
+        },
+
+        // Upsert a header.
+        setFastlyHeader: (version, header, cb) => {
+            if (!serviceId) return cb('Failed to set header. No serviceId configured');
+            const fields = Object.assign(base(version), header);
+            return toCallback(upsert(
+                () => headerApi.updateHeaderObject(Object.assign({header_name: header.name}, fields)),
+                () => headerApi.createHeaderObject(fields)
+            ), cb);
+        },
+
+        // Upsert a response object.
+        setResponseObject: (version, responseObject, cb) => {
+            if (!serviceId) return cb('Failed to set response object. No serviceId configured');
+            const fields = Object.assign(base(version), responseObject);
+            return toCallback(upsert(
+                () => responseObjectApi.updateResponseObject(
+                    Object.assign({response_object_name: responseObject.name}, fields)
+                ),
+                () => responseObjectApi.createResponseObject(fields)
+            ), cb);
+        },
+
+        // Upsert a custom VCL include.
+        setCustomVCL: (version, name, vcl, cb) => {
+            if (!serviceId) return cb('Failed to set custom VCL. No serviceId configured');
+            const fields = Object.assign(base(version), {name: name, content: vcl});
+            return toCallback(upsert(
+                () => vclApi.updateCustomVcl(Object.assign({vcl_name: name}, fields)),
+                () => vclApi.createCustomVcl(fields)
+            ), cb);
+        },
+
+        // Purge all content tagged with a surrogate key.
+        purgeKey: (servId, key, cb) => toCallback(
+            purgeApi.purgeTag({service_id: servId, surrogate_key: key}),
+            cb
+        )
     };
-
-    /*
-     * getLatestActiveVersion: Get the most recent version for the configured service
-     *
-     * @param {callback} Callback with signature *err, latestVersion)
-     */
-    fastly.getLatestActiveVersion = function (cb) {
-        if (!this.serviceId) {
-            return cb('Failed to get latest version. No serviceId configured');
-        }
-        const url = `/service/${encodeURIComponent(this.serviceId)}/version`;
-        this.request('GET', url, (err, versions) => {
-            if (err) {
-                return cb(`Failed to fetch versions: ${err}`);
-            }
-            const latestVersion = versions.reduce((latestActiveSoFar, cur) => {
-                // if one of [latestActiveSoFar, cur] is active and the other isn't,
-                // return whichever is active. If both are not active, return
-                // latestActiveSoFar.
-                if (!cur || !cur.active) return latestActiveSoFar;
-                if (!latestActiveSoFar || !latestActiveSoFar.active) return cur;
-                // when both are active, prefer whichever has a higher version number.
-                return (cur.number > latestActiveSoFar.number) ? cur : latestActiveSoFar;
-            }, null);
-            return cb(null, latestVersion);
-        });
-    };
-
-    /*
-     * setCondition: Upsert a Fastly condition entry
-     * Attempts to PUT and POSTs if the PUT request is a 404
-     *
-     * @param {number} Version number
-     * @param {object} Condition object sent to the API
-     * @param {callback} Callback for fastly.request
-     */
-    fastly.setCondition = function (version, condition, cb) {
-        if (!this.serviceId) {
-            return cb('Failed to set condition. No serviceId configured');
-        }
-        const name = condition.name;
-        const putUrl = `${this.getFastlyAPIPrefix(this.serviceId, version)}/condition/${encodeURIComponent(name)}`;
-        const postUrl = `${this.getFastlyAPIPrefix(this.serviceId, version)}/condition`;
-        return this.request('PUT', putUrl, condition, (err, response) => {
-            if (err && err.statusCode === 404) {
-                this.request('POST', postUrl, condition, (e, resp) => {
-                    if (e) {
-                        return cb(`Failed while inserting condition "${condition.statement}": ${e}`);
-                    }
-                    return cb(null, resp);
-                });
-                return;
-            }
-            if (err) {
-                return cb(`Failed to update condition "${condition.statement}": ${err}`);
-            }
-            return cb(null, response);
-        });
-    };
-
-    /*
-     * setFastlyHeader: Upsert a Fastly header entry
-     * Attempts to PUT and POSTs if the PUT request is a 404
-     *
-     * @param {number} Version number
-     * @param {object} Header object sent to the API
-     * @param {callback} Callback for fastly.request
-     */
-    fastly.setFastlyHeader = function (version, header, cb) {
-        if (!this.serviceId) {
-            cb('Failed to set header. No serviceId configured');
-        }
-        const name = header.name;
-        const putUrl = `${this.getFastlyAPIPrefix(this.serviceId, version)}/header/${encodeURIComponent(name)}`;
-        const postUrl = `${this.getFastlyAPIPrefix(this.serviceId, version)}/header`;
-        return this.request('PUT', putUrl, header, (err, response) => {
-            if (err && err.statusCode === 404) {
-                this.request('POST', postUrl, header, (e, resp) => {
-                    if (e) {
-                        return cb(`Failed to insert header: ${e}`);
-                    }
-                    return cb(null, resp);
-                });
-                return;
-            }
-            if (err) {
-                return cb(`Failed to update header: ${err}`);
-            }
-            return cb(null, response);
-        });
-    };
-
-    /*
-     * setResponseObject: Upsert a Fastly response object
-     * Attempts to PUT and POSTs if the PUT request is a 404
-     *
-     * @param {number} Version number
-     * @param {object} Response object sent to the API
-     * @param {callback} Callback for fastly.request
-     */
-    fastly.setResponseObject = function (version, responseObj, cb) {
-        if (!this.serviceId) {
-            cb('Failed to set response object. No serviceId configured');
-        }
-        const name = responseObj.name;
-        const putUrl =
-            `${this.getFastlyAPIPrefix(this.serviceId, version)}/response_object/${encodeURIComponent(name)}`;
-        const postUrl = `${this.getFastlyAPIPrefix(this.serviceId, version)}/response_object`;
-        return this.request('PUT', putUrl, responseObj, (err, response) => {
-            if (err && err.statusCode === 404) {
-                this.request('POST', postUrl, responseObj, (e, resp) => {
-                    if (e) {
-                        return cb(`Failed to insert response object: ${e}`);
-                    }
-                    return cb(null, resp);
-                });
-                return;
-            }
-            if (err) {
-                return cb(`Failed to update response object: ${err}`);
-            }
-            return cb(null, response);
-        });
-    };
-
-    /*
-     * cloneVersion: Clone a version to create a new version
-     *
-     * @param {number} Version to clone
-     * @param {callback} Callback for fastly.request
-     */
-    fastly.cloneVersion = function (version, cb) {
-        if (!this.serviceId) return cb('Failed to clone version. No serviceId configured.');
-        const url = `${this.getFastlyAPIPrefix(this.serviceId, version)}/clone`;
-        this.request('PUT', url, cb);
-    };
-
-    /*
-     * activateVersion: Activate a version
-     *
-     * @param {number} Version number
-     * @param {callback} Callback for fastly.request
-     */
-    fastly.activateVersion = function (version, cb) {
-        if (!this.serviceId) return cb('Failed to activate version. No serviceId configured.');
-        const url = `${this.getFastlyAPIPrefix(this.serviceId, version)}/activate`;
-        this.request('PUT', url, cb);
-    };
-
-    /*
-     * Upsert a custom vcl file. Attempts a PUT, and falls back
-     * to POST if not there already.
-     *
-     * @param {number}   version current version number for fastly service
-     * @param {string}   name    name of the custom vcl file to be upserted
-     * @param {string}   vcl     stringified custom vcl to be uploaded
-     * @param {Function} cb      function that takes in two args: err, response
-     */
-    fastly.setCustomVCL = function (version, name, vcl, cb) {
-        if (!this.serviceId) {
-            return cb('Failed to set response object. No serviceId configured');
-        }
-
-        const url = `${this.getFastlyAPIPrefix(this.serviceId, version)}/vcl/${name}`;
-        const postUrl = `${this.getFastlyAPIPrefix(this.serviceId, version)}/vcl`;
-        const content = {content: vcl};
-        return this.request('PUT', url, content, (err, response) => {
-            if (err && err.statusCode === 404) {
-                content.name = name;
-                this.request('POST', postUrl, content, (e, resp) => {
-                    if (e) {
-                        return cb(`Failed while adding custom vcl "${name}": ${e}`);
-                    }
-                    return cb(null, resp);
-                });
-                return;
-            }
-            if (err) {
-                return cb(`Failed to update custom vcl "${name}": ${err}`);
-            }
-            return cb(null, response);
-        });
-    };
-
-    return fastly;
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -65,7 +65,7 @@
         "eslint-plugin-json": "2.1.2",
         "eslint-plugin-react": "7.37.5",
         "eslint-plugin-react-hooks": "4.6.2",
-        "fastly": "1.2.1",
+        "fastly": "^15.1.0",
         "file-loader": "6.2.0",
         "formik": "2.4.9",
         "formsy-react": "1.1.6",
@@ -9108,6 +9108,16 @@
         "compare-cell": "^1.0.0"
       }
     },
+    "node_modules/component-emitter": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.1.tgz",
+      "integrity": "sha512-T0+barUSQRTUQASh8bx02dl+DhF54GtIDY13Y3m9oWTklKbb3Wv974meRpeZ3lp1JpLVECWWNHC4vaG2XHXouQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/computed-style-to-inline-style": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/computed-style-to-inline-style/-/computed-style-to-inline-style-3.0.0.tgz",
@@ -9239,6 +9249,13 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
+      "license": "MIT"
+    },
+    "node_modules/cookiejar": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.4.tgz",
+      "integrity": "sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/copy-to-clipboard": {
@@ -12617,6 +12634,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-safe-stringify": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/fast-shallow-equal": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fast-shallow-equal/-/fast-shallow-equal-1.0.0.tgz",
@@ -12662,15 +12686,13 @@
       "license": "CC0-1.0"
     },
     "node_modules/fastly": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/fastly/-/fastly-1.2.1.tgz",
-      "integrity": "sha512-2AL0lNUmeXu0UCL/jW69axPfG+VElfg2dZOZPsmfSD1Bf5YVAOlnhXeDeiJHtpQ4W44a4OLSC440DkePZOP72A==",
+      "version": "15.1.0",
+      "resolved": "https://registry.npmjs.org/fastly/-/fastly-15.1.0.tgz",
+      "integrity": "sha512-qHZBEJfjAoPqVCNOQLOKrdZY8aSr/AdVET9/uK951+oSlW5We+l9v88IqxpeUyAZygOIKoFS+MnLI19iDPmBDQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "request": "~2.12.0"
-      },
-      "engines": {
-        "node": ">=0.8"
+        "superagent": "^6.1.0"
       }
     },
     "node_modules/fastq": {
@@ -13088,6 +13110,17 @@
       "integrity": "sha512-k7WqXkEzgXkW4wkHdS6Cv2Ou0rIFtiDelZjgoe1saW4p7FT7zS8OeAUpAekhormqzpeecR97e4vBft1zMsfFOQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/formidable": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.2.6.tgz",
+      "integrity": "sha512-KcpbcpuLNOwrEjnbpMC0gS+X8ciDoZE1kkqzat4a8vrprf+s9pKNQ/QIwWfbfs4ltgmFl3MD177SNTkve3BwGQ==",
+      "deprecated": "Please upgrade to latest, formidable@v2 or formidable@v3! Check these notes: https://bit.ly/2ZEqIau",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://ko-fi.com/tunnckoCore/commissions"
+      }
     },
     "node_modules/formik": {
       "version": "2.4.9",
@@ -14781,9 +14814,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -22853,72 +22886,6 @@
         "node": ">=0.10"
       }
     },
-    "node_modules/request": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/request/-/request-2.12.0.tgz",
-      "integrity": "sha512-GcOI9NyUw2lRke4kdbrjQFxu+cLugShENHvcb9QCSLLc/yH3lP7I/7RESxVbYS+AxC/r9rwzks52MRHVoZdb5w==",
-      "bundleDependencies": [
-        "form-data",
-        "mime"
-      ],
-      "deprecated": "request has been deprecated, see https://github.com/request/request/issues/3142",
-      "dev": true,
-      "engines": [
-        "node >= 0.3.6"
-      ],
-      "dependencies": {
-        "form-data": "~0.0.3",
-        "mime": "~1.2.7"
-      }
-    },
-    "node_modules/request/node_modules/form-data": {
-      "version": "0.0.3",
-      "dev": true,
-      "inBundle": true,
-      "dependencies": {
-        "async": "~0.1.9",
-        "combined-stream": "0.0.3",
-        "mime": "~1.2.2"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/request/node_modules/form-data/node_modules/async": {
-      "version": "0.1.9",
-      "dev": true,
-      "inBundle": true,
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/request/node_modules/form-data/node_modules/combined-stream": {
-      "version": "0.0.3",
-      "dev": true,
-      "inBundle": true,
-      "dependencies": {
-        "delayed-stream": "0.0.5"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/request/node_modules/form-data/node_modules/combined-stream/node_modules/delayed-stream": {
-      "version": "0.0.5",
-      "dev": true,
-      "inBundle": true,
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
-    "node_modules/request/node_modules/mime": {
-      "version": "1.2.7",
-      "dev": true,
-      "inBundle": true,
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -25189,6 +25156,73 @@
       "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.3.6.tgz",
       "integrity": "sha512-yQ3rwFWRfwNUY7H5vpU0wfdkNSnvnJinhF9830Swlaxl03zsOjCfmX0ugac+3LtK0lYSgwL/KXc8oYL3mG4YFQ==",
       "license": "MIT"
+    },
+    "node_modules/superagent": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-6.1.0.tgz",
+      "integrity": "sha512-OUDHEssirmplo3F+1HWKUrUjvnQuA+nZI6i/JJBdXb5eq9IyEQwPyPpqND+SSsxf6TygpBEkUjISVRN4/VOpeg==",
+      "deprecated": "Please upgrade to superagent v10.2.2+, see release notes at https://github.com/forwardemail/superagent/releases/tag/v10.2.2 - maintenance is supported by Forward Email @ https://forwardemail.net",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "component-emitter": "^1.3.0",
+        "cookiejar": "^2.1.2",
+        "debug": "^4.1.1",
+        "fast-safe-stringify": "^2.0.7",
+        "form-data": "^3.0.0",
+        "formidable": "^1.2.2",
+        "methods": "^1.1.2",
+        "mime": "^2.4.6",
+        "qs": "^6.9.4",
+        "readable-stream": "^3.6.0",
+        "semver": "^7.3.2"
+      },
+      "engines": {
+        "node": ">= 7.0.0"
+      }
+    },
+    "node_modules/superagent/node_modules/form-data": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.5.tgz",
+      "integrity": "sha512-j23EibVLnp4zNXGW7LjryXYa2X6U/M96yoOX+ybZxwkYajdxRNEqYY3zhh7y0i6kfISKS2jr+EJq1YTUDEv5+w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/superagent/node_modules/mime": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
+      "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/superagent/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/supercluster": {
       "version": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "eslint-plugin-json": "2.1.2",
     "eslint-plugin-react": "7.37.5",
     "eslint-plugin-react-hooks": "4.6.2",
-    "fastly": "1.2.1",
+    "fastly": "^15.1.0",
     "file-loader": "6.2.0",
     "formik": "2.4.9",
     "formsy-react": "1.1.6",

--- a/test/unit/lib/fastly-extended.test.js
+++ b/test/unit/lib/fastly-extended.test.js
@@ -1,160 +1,228 @@
 describe('fastly library', () => {
-    let mockedFastlyRequest = {};
+    let mockListServiceVersions = jest.fn();
+    // Recorded {api, method, args} for every non-version API call, reset per test.
+    let mockCalls = [];
+    // When true, every update* call rejects with a 404 so the upsert falls back to create.
+    let mockUpdate404 = false;
 
-    jest.mock('fastly', () => (() => ({
-        request: mockedFastlyRequest
-    })));
+    // A fastly@15 API stub whose every method records its call and returns a promise.
+    // listServiceVersions is routed to mockListServiceVersions so the getLatestActiveVersion
+    // tests can control the version list.
+    const mockApi = name => jest.fn(() => new Proxy({}, {
+        get: (target, method) => (...args) => {
+            if (name === 'VersionApi' && method === 'listServiceVersions') {
+                return mockListServiceVersions(...args);
+            }
+            const callArgs = args[0];
+            mockCalls.push({api: name, method: String(method), args: callArgs});
+            if (String(method).startsWith('update') && mockUpdate404) {
+                const err = new Error('not found');
+                err.status = 404;
+                return Promise.reject(err);
+            }
+            return Promise.resolve({name: callArgs && callArgs.name, number: 42});
+        }
+    }));
+
+    // Mock the fastly@15 client surface that fastly-extended constructs.
+    jest.mock('fastly', () => ({
+        ApiClient: {instance: {authenticate: jest.fn()}},
+        VersionApi: mockApi('VersionApi'),
+        ConditionApi: mockApi('ConditionApi'),
+        HeaderApi: mockApi('HeaderApi'),
+        ResponseObjectApi: mockApi('ResponseObjectApi'),
+        VclApi: mockApi('VclApi'),
+        PurgeApi: mockApi('PurgeApi')
+    }));
     const fastlyExtended = require('../../../bin/lib/fastly-extended'); // eslint-disable-line global-require
+
+    const withVersions = versions => {
+        mockListServiceVersions = jest.fn(() => Promise.resolve(versions));
+    };
 
     test('getLatestActiveVersion returns largest active VCL number, ' +
         'when called with VCLs in sequential order', done => {
-        mockedFastlyRequest = jest.fn((method, url, cb) => {
-            cb(null, [
-                {
-                    number: 1,
-                    active: false
-                },
-                {
-                    number: 2,
-                    active: false
-                },
-                {
-                    number: 3,
-                    active: true
-                },
-                {
-                    number: 4,
-                    active: false
-                }
-            ]);
-        });
+        withVersions([
+            {number: 1, active: false},
+            {number: 2, active: false},
+            {number: 3, active: true},
+            {number: 4, active: false}
+        ]);
         const fastlyInstance = fastlyExtended('api_key', 'service_id');
 
         fastlyInstance.getLatestActiveVersion((err, response) => {
             expect(err).toBe(null);
-            expect(response).toEqual({
-                number: 3,
-                active: true
-            });
-            expect(mockedFastlyRequest).toHaveBeenCalledWith(
-                'GET', '/service/service_id/version', expect.any(Function)
-            );
+            expect(response).toEqual({number: 3, active: true});
+            expect(mockListServiceVersions).toHaveBeenCalledWith({service_id: 'service_id'});
             done();
         });
     });
 
     test('getLatestActiveVersion returns largest active VCL number, when called with VCLs in mixed up order', done => {
-        mockedFastlyRequest = jest.fn((method, url, cb) => {
-            cb(null, [
-                {
-                    number: 4,
-                    active: false
-                },
-                {
-                    number: 1,
-                    active: false
-                },
-                {
-                    number: 2,
-                    active: true
-                },
-                {
-                    number: 3,
-                    active: false
-                }
-            ]);
-        });
+        withVersions([
+            {number: 4, active: false},
+            {number: 1, active: false},
+            {number: 2, active: true},
+            {number: 3, active: false}
+        ]);
         const fastlyInstance = fastlyExtended('api_key', 'service_id');
 
         fastlyInstance.getLatestActiveVersion((err, response) => {
             expect(err).toBe(null);
-            expect(response).toEqual({
-                number: 2,
-                active: true
-            });
-            expect(mockedFastlyRequest).toHaveBeenCalledWith(
-                'GET', '/service/service_id/version', expect.any(Function)
-            );
+            expect(response).toEqual({number: 2, active: true});
+            expect(mockListServiceVersions).toHaveBeenCalledWith({service_id: 'service_id'});
             done();
         });
     });
 
     test('getLatestActiveVersion returns null, when none of the VCL versions are active', done => {
-        mockedFastlyRequest = jest.fn((method, url, cb) => {
-            cb(null, [
-                {
-                    number: 4,
-                    active: false
-                },
-                {
-                    number: 1,
-                    active: false
-                },
-                {
-                    number: 2,
-                    active: false
-                },
-                {
-                    number: 3,
-                    active: false
-                }
-            ]);
-        });
+        withVersions([
+            {number: 4, active: false},
+            {number: 1, active: false},
+            {number: 2, active: false},
+            {number: 3, active: false}
+        ]);
         const fastlyInstance = fastlyExtended('api_key', 'service_id');
 
         fastlyInstance.getLatestActiveVersion((err, response) => {
             expect(err).toBe(null);
             expect(response).toEqual(null);
-            expect(mockedFastlyRequest).toHaveBeenCalledWith(
-                'GET', '/service/service_id/version', expect.any(Function)
-            );
+            expect(mockListServiceVersions).toHaveBeenCalledWith({service_id: 'service_id'});
             done();
         });
     });
 
     test('getLatestActiveVersion returns largest active VCL number, ' +
         'when called with a single active VCL', done => {
-        mockedFastlyRequest = jest.fn((method, url, cb) => {
-            cb(null, [
-                {
-                    number: 1,
-                    active: true
-                }
-            ]);
-        });
+        withVersions([
+            {number: 1, active: true}
+        ]);
         const fastlyInstance = fastlyExtended('api_key', 'service_id');
 
         fastlyInstance.getLatestActiveVersion((err, response) => {
             expect(err).toBe(null);
-            expect(response).toEqual({
-                number: 1,
-                active: true
-            });
-            expect(mockedFastlyRequest).toHaveBeenCalledWith(
-                'GET', '/service/service_id/version', expect.any(Function)
-            );
+            expect(response).toEqual({number: 1, active: true});
+            expect(mockListServiceVersions).toHaveBeenCalledWith({service_id: 'service_id'});
             done();
         });
     });
 
     test('getLatestActiveVersion returns null, when called with a single inactive VCL', done => {
-        mockedFastlyRequest = jest.fn((method, url, cb) => {
-            cb(null, [
-                {
-                    number: 1,
-                    active: false
-                }
-            ]);
-        });
+        withVersions([
+            {number: 1, active: false}
+        ]);
         const fastlyInstance = fastlyExtended('api_key', 'service_id');
 
         fastlyInstance.getLatestActiveVersion((err, response) => {
             expect(err).toBe(null);
             expect(response).toEqual(null);
-            expect(mockedFastlyRequest).toHaveBeenCalledWith(
-                'GET', '/service/service_id/version', expect.any(Function)
-            );
+            expect(mockListServiceVersions).toHaveBeenCalledWith({service_id: 'service_id'});
             done();
+        });
+    });
+
+    describe('wrapper wiring to the fastly@15 API', () => {
+        const fastlyInstance = fastlyExtended('api_key', 'service_id');
+        // Bridge the wrapper's (err, result) callbacks into a promise for async tests.
+        const call = fn => new Promise((resolve, reject) => {
+            fn((err, result) => (err ? reject(err) : resolve(result)));
+        });
+        const lastCall = () => mockCalls[mockCalls.length - 1];
+
+        beforeEach(() => {
+            mockCalls = [];
+            mockUpdate404 = false;
+        });
+
+        test('setCondition updates an existing condition with the merged params', async () => {
+            await call(cb => fastlyInstance.setCondition(7, {
+                name: 'routes/x (request)', statement: 'req.url ~ "x"', type: 'REQUEST', priority: 11
+            }, cb));
+            expect(mockCalls).toHaveLength(1);
+            expect(lastCall()).toEqual({api: 'ConditionApi',
+                method: 'updateCondition',
+                args: {
+                    service_id: 'service_id',
+                    version_id: 7,
+                    condition_name: 'routes/x (request)',
+                    name: 'routes/x (request)',
+                    statement: 'req.url ~ "x"',
+                    type: 'REQUEST',
+                    priority: 11
+                }});
+        });
+
+        test('setCondition falls back to createCondition on a 404', async () => {
+            mockUpdate404 = true;
+            await call(cb => fastlyInstance.setCondition(7, {
+                name: 'c', statement: 's', type: 'REQUEST', priority: 1
+            }, cb));
+            expect(mockCalls.map(c => `${c.api}.${c.method}`)).toEqual(
+                ['ConditionApi.updateCondition', 'ConditionApi.createCondition']
+            );
+            // The create body carries no *_name path param.
+            expect(lastCall().args).toEqual({
+                service_id: 'service_id', version_id: 7, name: 'c', statement: 's', type: 'REQUEST', priority: 1
+            });
+        });
+
+        test('setFastlyHeader uses header_name to update and omits it when creating', async () => {
+            mockUpdate404 = true;
+            await call(cb => fastlyInstance.setFastlyHeader(7, {
+                name: 'rewrites/a',
+                action: 'set',
+                ignore_if_set: 0,
+                type: 'REQUEST',
+                dst: 'url',
+                src: '"/a.html"',
+                request_condition: 'rc',
+                priority: 10
+            }, cb));
+            expect(mockCalls[0].method).toBe('updateHeaderObject');
+            expect(mockCalls[0].args.header_name).toBe('rewrites/a');
+            expect(mockCalls[1].method).toBe('createHeaderObject');
+            expect(mockCalls[1].args.dst).toBe('url');
+            expect(mockCalls[1].args.header_name).toBeUndefined();
+        });
+
+        test('setResponseObject updates with response_object_name', async () => {
+            await call(cb => fastlyInstance.setResponseObject(7, {
+                name: 'redirects/a', status: 301, response: 'Moved Permanently', request_condition: 'rc'
+            }, cb));
+            expect(lastCall().method).toBe('updateResponseObject');
+            expect(lastCall().args.response_object_name).toBe('redirects/a');
+            expect(lastCall().args.status).toBe(301);
+        });
+
+        test('setCustomVCL updates with vcl_name and content', async () => {
+            await call(cb => fastlyInstance.setCustomVCL(7, 'recv-condition', 'if (true) {}', cb));
+            expect(lastCall().method).toBe('updateCustomVcl');
+            expect(lastCall().args.vcl_name).toBe('recv-condition');
+            expect(lastCall().args.content).toBe('if (true) {}');
+        });
+
+        test('purgeKey calls purgeTag with the surrogate key', async () => {
+            await call(cb => fastlyInstance.purgeKey('service_id', 'static-assets', cb));
+            expect(lastCall()).toEqual({api: 'PurgeApi',
+                method: 'purgeTag',
+                args: {
+                    service_id: 'service_id', surrogate_key: 'static-assets'
+                }});
+        });
+
+        test('cloneVersion and activateVersion hit the version API', async () => {
+            await call(cb => fastlyInstance.cloneVersion(7, cb));
+            expect(lastCall()).toEqual({api: 'VersionApi',
+                method: 'cloneServiceVersion',
+                args: {
+                    service_id: 'service_id', version_id: 7
+                }});
+            await call(cb => fastlyInstance.activateVersion(7, cb));
+            expect(lastCall()).toEqual({api: 'VersionApi',
+                method: 'activateServiceVersion',
+                args: {
+                    service_id: 'service_id', version_id: 7
+                }});
         });
     });
 });


### PR DESCRIPTION
### Resolves:

No single tracking issue. This is prep work for the upcoming Fastly config
refactor. Isolating the major client bump on its own keeps the refactor PR a
focused, reviewable change.

### Changes:

Migrate `bin/lib/fastly-extended.js` from the legacy `fastly@1.2.1` callback
`request()` client to the official `fastly@15` API classes (Version, Condition,
Header, ResponseObject, Vcl, Purge).

The wrapper keeps its exact callback method surface, so `bin/configure-fastly.js`
and its `async.auto` flow are untouched: only how the wrapper talks to Fastly
changes. The upsert behavior (update, then create on a 404) is preserved.

- `fastly` devDependency `1.2.1` becomes `^15.1.0`.
- `test/unit/lib/fastly-extended.test.js` is updated to mock the v15 surface and
  now also covers the wrapper wiring (see Test Coverage).

### Test Coverage:

`test/unit/lib/fastly-extended.test.js` (12 Jest tests, all in the diff):

- `getLatestActiveVersion`: 5 cases (sequential, mixed, and single active
  orderings, plus none-active).
- Wrapper wiring: each method hits the correct v15 API with the correct params,
  including the update-then-create-on-404 upsert (asserting the create body drops
  the `*_name` path param) and the surrogate-key purge.
- eslint is clean.

Note: this verification is mock-based. The final end-to-end check is a
`configure-fastly` dry run against staging (with `FASTLY_ACTIVATE_CHANGES`
unset) before it reaches production via master.
