### PR TITLE
refactor: make the Fastly config promise-native

### DIFF
--- a/bin/configure-fastly.js
+++ b/bin/configure-fastly.js
@@ -1,4 +1,3 @@
-const async = require('async');
 const defaults = require('lodash.defaults');
 const fastlyConfig = require('./lib/fastly-config-methods');
 const languages = require('scratch-l10n').default;
@@ -19,273 +18,184 @@ const extraAppRoutes = [
     '/[^/]*.html$'
 ];
 
-const routeJsonPreProcessed = routeJson.map(
-    route => {
-        if (route.redirect) {
-            process.stdout.write(`Updating: ${route.redirect} to `);
-            route.redirect = route.redirect.replace('RADISH_URL', RADISH_URL);
-            process.stdout.write(`${route.redirect}\n`);
-        }
-        return route;
+const routes = routeJson.map(route => {
+    if (route.redirect) {
+        process.stdout.write(`Updating: ${route.redirect} to `);
+        route.redirect = route.redirect.replace('RADISH_URL', RADISH_URL);
+        process.stdout.write(`${route.redirect}\n`);
     }
-);
-const routes = routeJsonPreProcessed.map(
-    route => defaults({}, {pattern: fastlyConfig.expressPatternToRegex(route.pattern)}, route)
-);
-
-async.auto({
-    version: function (cb) {
-        fastly.getLatestActiveVersion((err, response) => {
-            if (err) return cb(err);
-            // Validate latest version before continuing
-            if (response.active || response.locked) {
-                fastly.cloneVersion(response.number, (e, resp) => {
-                    if (e) return cb(`Failed to clone latest version: ${e}`);
-                    cb(null, resp.number);
-                });
-            } else {
-                cb(null, response.number);
-            }
-        });
-    },
-    recvCustomVCL: ['version', function (results, cb) {
-        // For all the routes in routes.js, construct a varnish-style regex that matches
-        // on any of those route conditions.
-        const notPassStatement = fastlyConfig.getAppRouteCondition('../build/*', routes, extraAppRoutes, __dirname);
-
-        // For a non-pass condition, point backend at s3
-        const recvCondition = `${'' +
-            'if ('}${notPassStatement}) {\n` +
-            `    set req.backend = F_s3;\n` +
-            `    set req.http.host = "${S3_BUCKET_NAME}";\n` +
-            `} else {\n` +
-            `    if (!req.http.Fastly-FF) {\n` +
-            `        if (req.http.X-Forwarded-For) {\n` +
-            `            set req.http.Fastly-Temp-XFF = req.http.X-Forwarded-For ", " client.ip;\n` +
-            `        } else {\n` +
-            `            set req.http.Fastly-Temp-XFF = client.ip;\n` +
-            `        }\n` +
-            `    } else {\n` +
-            `        set req.http.Fastly-Temp-XFF = req.http.X-Forwarded-For;\n` +
-            `    }\n` +
-            `    set req.grace = 60s;\n` +
-            `    if (req.http.Cookie:scratchlanguage) {\n` +
-            `        set req.http.Accept-Language = req.http.Cookie:scratchlanguage;\n` +
-            `    } else {\n` +
-            `        set req.http.Accept-Language = accept.language_lookup("${
-                Object.keys(languages).join(':')}", ` +
-                         `"en", ` +
-                         `std.tolower(req.http.Accept-Language)` +
-                     `);\n` +
-            `    }\n` +
-            `    if (req.url ~ "^(/projects/|/fragment/account-nav.json|/session/)" && ` +
-            `!req.http.Cookie:scratchsessionsid) {\n` +
-            `        set req.http.Cookie = "scratchlanguage=" req.http.Cookie:scratchlanguage;\n` +
-            `    } else {\n` +
-            `        return(pass);\n` +
-            `    }\n` +
-            `}\n`;
-
-
-        fastly.setCustomVCL(
-            results.version,
-            'recv-condition',
-            recvCondition,
-            cb
-        );
-    }],
-    fetchCustomVCL: ['version', function (results, cb) {
-        const passStatement = fastlyConfig.negateConditionStatement(
-            fastlyConfig.getAppRouteCondition('../build/*', routes, extraAppRoutes, __dirname)
-        );
-        const ttlCondition = fastlyConfig.setResponseTTL(passStatement);
-        fastly.setCustomVCL(results.version, 'fetch-condition', ttlCondition, cb);
-    }],
-    appRouteRequestConditions: ['version', function (results, cb) {
-        const conditions = {};
-        async.forEachOf(routes, (route, id, cb2) => {
-            const condition = {
-                name: fastlyConfig.getConditionNameForRoute(route, 'request'),
-                statement: `req.url.path ~ "${route.pattern}"`,
-                type: 'REQUEST',
-                // Priority needs to be > 1 to not interact with http->https redirect
-                priority: 10 + id
-            };
-            fastly.setCondition(results.version, condition, (err, response) => {
-                if (err) return cb2(err);
-                conditions[id] = response;
-                cb2(null, response);
-            });
-        }, err => {
-            if (err) return cb(err);
-            cb(null, conditions);
-        });
-    }],
-    appRouteHeaders: ['version', 'appRouteRequestConditions', function (results, cb) {
-        const headers = {};
-        async.forEachOf(routes, (route, id, cb2) => {
-            if (route.redirect) {
-                async.auto({
-                    responseCondition: function (cb3) {
-                        const condition = {
-                            name: fastlyConfig.getConditionNameForRoute(route, 'response'),
-                            statement: `req.url.path ~ "${route.pattern}"`,
-                            type: 'RESPONSE',
-                            priority: id
-                        };
-                        fastly.setCondition(results.version, condition, cb3);
-                    },
-                    responseObject: function (cb3) {
-                        const responseObject = {
-                            name: fastlyConfig.getResponseNameForRoute(route),
-                            status: 301,
-                            response: 'Moved Permanently',
-                            request_condition: fastlyConfig.getConditionNameForRoute(route, 'request')
-                        };
-                        fastly.setResponseObject(results.version, responseObject, cb3);
-                    },
-                    redirectHeader: ['responseCondition', function (redirectResults, cb3) {
-                        const header = {
-                            name: fastlyConfig.getHeaderNameForRoute(route),
-                            action: 'set',
-                            ignore_if_set: 0,
-                            type: 'RESPONSE',
-                            dst: 'http.Location',
-                            src: `"${route.redirect}"`,
-                            response_condition: redirectResults.responseCondition.name
-                        };
-                        fastly.setFastlyHeader(results.version, header, cb3);
-                    }]
-                }, (err, redirectResults) => {
-                    if (err) return cb2(err);
-                    headers[id] = redirectResults.redirectHeader;
-                    cb2(null, redirectResults);
-                });
-            } else {
-                const header = {
-                    name: fastlyConfig.getHeaderNameForRoute(route, 'request'),
-                    action: 'set',
-                    ignore_if_set: 0,
-                    type: 'REQUEST',
-                    dst: 'url',
-                    src: `"/${route.name}.html"`,
-                    request_condition: results.appRouteRequestConditions[id].name,
-                    priority: 10
-                };
-                fastly.setFastlyHeader(results.version, header, (err, response) => {
-                    if (err) return cb2(err);
-                    headers[id] = response;
-                    cb2(null, response);
-                });
-            }
-        }, err => {
-            if (err) return cb(err);
-            cb(null, headers);
-        });
-    }],
-    tipbarRedirectHeaders: ['version', function (results, cb) {
-        async.auto({
-            requestCondition: function (cb2) {
-                const condition = {
-                    name: 'routes/?tip_bar= (request)',
-                    statement: 'req.url ~ "\\?tip_bar="',
-                    type: 'REQUEST',
-                    priority: 10
-                };
-                fastly.setCondition(results.version, condition, cb2);
-            },
-            responseCondition: function (cb2) {
-                const condition = {
-                    name: 'routes/?tip_bar= (response)',
-                    statement: 'req.url ~ "\\?tip_bar="',
-                    type: 'RESPONSE',
-                    priority: 10
-                };
-                fastly.setCondition(results.version, condition, cb2);
-            },
-            responseObject: ['requestCondition', function (redirectResults, cb2) {
-                const responseObject = {
-                    name: 'redirects/?tip_bar=',
-                    status: 301,
-                    response: 'Moved Permanently',
-                    request_condition: redirectResults.requestCondition.name
-                };
-                fastly.setResponseObject(results.version, responseObject, cb2);
-            }],
-            redirectHeader: ['responseCondition', function (redirectResults, cb2) {
-                const header = {
-                    name: 'redirects/?tip_bar=',
-                    action: 'set',
-                    ignore_if_set: 0,
-                    type: 'RESPONSE',
-                    dst: 'http.Location',
-                    src: 'regsub(req.url, "tip_bar=", "tutorial=")',
-                    response_condition: redirectResults.responseCondition.name
-                };
-                fastly.setFastlyHeader(results.version, header, cb2);
-            }]
-        }, (err, redirectResults) => {
-            if (err) return cb(err);
-            cb(null, redirectResults);
-        });
-    }],
-    embedRedirectHeaders: ['version', function (results, cb) {
-        async.auto({
-            requestCondition: function (cb2) {
-                const condition = {
-                    name: 'routes/projects/embed (request)',
-                    statement: 'req.url.path ~ "^/projects/embed/(\\d+)"',
-                    type: 'REQUEST',
-                    priority: 10
-                };
-                fastly.setCondition(results.version, condition, cb2);
-            },
-            responseCondition: function (cb2) {
-                const condition = {
-                    name: 'routes/projects/embed (response)',
-                    statement: 'req.url.path ~ "^/projects/embed/(\\d+)"',
-                    type: 'RESPONSE',
-                    priority: 10
-                };
-                fastly.setCondition(results.version, condition, cb2);
-            },
-            responseObject: ['requestCondition', function (redirectResults, cb2) {
-                const responseObject = {
-                    name: 'redirects/projects/embed',
-                    status: 301,
-                    response: 'Moved Permanently',
-                    request_condition: redirectResults.requestCondition.name
-                };
-                fastly.setResponseObject(results.version, responseObject, cb2);
-            }],
-            redirectHeader: ['responseCondition', function (redirectResults, cb2) {
-                const header = {
-                    name: 'redirects/projects/embed',
-                    action: 'set',
-                    ignore_if_set: 0,
-                    type: 'RESPONSE',
-                    dst: 'http.Location',
-                    src: '"/projects/" + re.group.1 + "/embed"',
-                    response_condition: redirectResults.responseCondition.name
-                };
-                fastly.setFastlyHeader(results.version, header, cb2);
-            }]
-        }, (err, redirectResults) => {
-            if (err) return cb(err);
-            cb(null, redirectResults);
-        });
-    }]
-}, (err, results) => {
-    if (err) throw new Error(err);
-    if (process.env.FASTLY_ACTIVATE_CHANGES) {
-        fastly.activateVersion(results.version, (e, resp) => {
-            if (e) throw new Error(e);
-            process.stdout.write(`Successfully configured and activated version ${resp.number}\n`);
-            // purge static-assets using surrogate key
-            fastly.purgeKey(FASTLY_SERVICE_ID, 'static-assets', error => {
-                if (error) throw new Error(error);
-                process.stdout.write('Purged static assets.\n');
-            });
-        });
-    }
+    return defaults({}, {pattern: fastlyConfig.expressPatternToRegex(route.pattern)}, route);
 });
+
+// Get the latest version, cloning it first if it is already active or locked.
+const getWorkingVersion = async () => {
+    const response = await fastly.getLatestActiveVersion();
+    if (response.active || response.locked) {
+        try {
+            const cloned = await fastly.cloneVersion(response.number);
+            return cloned.number;
+        } catch (err) {
+            throw new Error(`Failed to clone latest version: ${err}`);
+        }
+    }
+    return response.number;
+};
+
+// The recv custom VCL: point matching app/static paths at S3, and pass
+// everything else through to the dynamic backend with language + XFF handling.
+const buildRecvCondition = () => {
+    const notPassStatement = fastlyConfig.getAppRouteCondition('../build/*', routes, extraAppRoutes, __dirname);
+    return `${'' +
+        'if ('}${notPassStatement}) {\n` +
+        `    set req.backend = F_s3;\n` +
+        `    set req.http.host = "${S3_BUCKET_NAME}";\n` +
+        `} else {\n` +
+        `    if (!req.http.Fastly-FF) {\n` +
+        `        if (req.http.X-Forwarded-For) {\n` +
+        `            set req.http.Fastly-Temp-XFF = req.http.X-Forwarded-For ", " client.ip;\n` +
+        `        } else {\n` +
+        `            set req.http.Fastly-Temp-XFF = client.ip;\n` +
+        `        }\n` +
+        `    } else {\n` +
+        `        set req.http.Fastly-Temp-XFF = req.http.X-Forwarded-For;\n` +
+        `    }\n` +
+        `    set req.grace = 60s;\n` +
+        `    if (req.http.Cookie:scratchlanguage) {\n` +
+        `        set req.http.Accept-Language = req.http.Cookie:scratchlanguage;\n` +
+        `    } else {\n` +
+        `        set req.http.Accept-Language = accept.language_lookup("${
+            Object.keys(languages).join(':')}", ` +
+                     `"en", ` +
+                     `std.tolower(req.http.Accept-Language)` +
+                 `);\n` +
+        `    }\n` +
+        `    if (req.url ~ "^(/projects/|/fragment/account-nav.json|/session/)" && ` +
+        `!req.http.Cookie:scratchsessionsid) {\n` +
+        `        set req.http.Cookie = "scratchlanguage=" req.http.Cookie:scratchlanguage;\n` +
+        `    } else {\n` +
+        `        return(pass);\n` +
+        `    }\n` +
+        `}\n`;
+};
+
+const buildFetchCondition = () => {
+    const passStatement = fastlyConfig.negateConditionStatement(
+        fastlyConfig.getAppRouteCondition('../build/*', routes, extraAppRoutes, __dirname)
+    );
+    return fastlyConfig.setResponseTTL(passStatement);
+};
+
+// A REQUEST condition per route, matching its url path. Resolves to the created
+// conditions keyed by route index, which the headers step references.
+const setAppRouteRequestConditions = version => Promise.all(routes.map((route, id) =>
+    fastly.setCondition(version, {
+        name: fastlyConfig.getConditionNameForRoute(route, 'request'),
+        statement: `req.url.path ~ "${route.pattern}"`,
+        type: 'REQUEST',
+        // Priority needs to be > 1 to not interact with http->https redirect
+        priority: 10 + id
+    })
+));
+
+// For each route, either a 301 redirect (response condition + response object +
+// Location header) or a rewrite of the clean url to its static html shell.
+const setAppRouteHeaders = (version, requestConditions) => Promise.all(routes.map((route, id) => {
+    if (route.redirect) {
+        const responseCondition = fastly.setCondition(version, {
+            name: fastlyConfig.getConditionNameForRoute(route, 'response'),
+            statement: `req.url.path ~ "${route.pattern}"`,
+            type: 'RESPONSE',
+            priority: id
+        });
+        const responseObject = fastly.setResponseObject(version, {
+            name: fastlyConfig.getResponseNameForRoute(route),
+            status: 301,
+            response: 'Moved Permanently',
+            request_condition: fastlyConfig.getConditionNameForRoute(route, 'request')
+        });
+        const redirectHeader = responseCondition.then(condition => fastly.setFastlyHeader(version, {
+            name: fastlyConfig.getHeaderNameForRoute(route),
+            action: 'set',
+            ignore_if_set: 0,
+            type: 'RESPONSE',
+            dst: 'http.Location',
+            src: `"${route.redirect}"`,
+            response_condition: condition.name
+        }));
+        return Promise.all([responseObject, redirectHeader]);
+    }
+    return fastly.setFastlyHeader(version, {
+        name: fastlyConfig.getHeaderNameForRoute(route, 'request'),
+        action: 'set',
+        ignore_if_set: 0,
+        type: 'REQUEST',
+        dst: 'url',
+        src: `"/${route.name}.html"`,
+        request_condition: requestConditions[id].name,
+        priority: 10
+    });
+}));
+
+// A special-case redirect whose request/response conditions share a statement,
+// and whose Location is derived from the request rather than a fixed route.
+const setDerivedRedirect = async (version, name, statement, locationSrc) => {
+    const [requestCondition, responseCondition] = await Promise.all([
+        fastly.setCondition(version, {
+            name: `routes/${name} (request)`, statement: statement, type: 'REQUEST', priority: 10
+        }),
+        fastly.setCondition(version, {
+            name: `routes/${name} (response)`, statement: statement, type: 'RESPONSE', priority: 10
+        })
+    ]);
+    await Promise.all([
+        fastly.setResponseObject(version, {
+            name: `redirects/${name}`,
+            status: 301,
+            response: 'Moved Permanently',
+            request_condition: requestCondition.name
+        }),
+        fastly.setFastlyHeader(version, {
+            name: `redirects/${name}`,
+            action: 'set',
+            ignore_if_set: 0,
+            type: 'RESPONSE',
+            dst: 'http.Location',
+            src: locationSrc,
+            response_condition: responseCondition.name
+        })
+    ]);
+};
+
+const configureFastly = async () => {
+    const version = await getWorkingVersion();
+    // The request conditions gate the app-route headers; everything else depends
+    // only on the version, so run it all concurrently.
+    const requestConditions = setAppRouteRequestConditions(version);
+    await Promise.all([
+        fastly.setCustomVCL(version, 'recv-condition', buildRecvCondition()),
+        fastly.setCustomVCL(version, 'fetch-condition', buildFetchCondition()),
+        requestConditions.then(conditions => setAppRouteHeaders(version, conditions)),
+        setDerivedRedirect(
+            version, '?tip_bar=', 'req.url ~ "\\?tip_bar="', 'regsub(req.url, "tip_bar=", "tutorial=")'
+        ),
+        setDerivedRedirect(
+            version, 'projects/embed', 'req.url.path ~ "^/projects/embed/(\\d+)"',
+            '"/projects/" + re.group.1 + "/embed"'
+        )
+    ]);
+    return version;
+};
+
+configureFastly()
+    .then(async version => {
+        if (!process.env.FASTLY_ACTIVATE_CHANGES) return;
+        const response = await fastly.activateVersion(version);
+        process.stdout.write(`Successfully configured and activated version ${response.number}\n`);
+        // Purge static assets using their surrogate key.
+        await fastly.purgeKey(FASTLY_SERVICE_ID, 'static-assets');
+        process.stdout.write('Purged static assets.\n');
+    })
+    .catch(err => {
+        process.stderr.write(`${err && err.stack ? err.stack : err}\n`);
+        process.exit(1);
+    });

--- a/bin/lib/fastly-extended.js
+++ b/bin/lib/fastly-extended.js
@@ -2,9 +2,8 @@ const Fastly = require('fastly');
 
 /*
  * Fastly configuration helpers for a particular service, built on the official
- * fastly-js client (v15+). Each method keeps the callback signature the callers
- * rely on -- `(...args, cb)` invoking `cb(err, result)` -- so the client bump is
- * isolated to this file.
+ * fastly-js client (v15+). Every method returns a Promise. Authenticates the
+ * shared ApiClient on construction.
  *
  * @param {string} apiKey    Fastly API token
  * @param {string} serviceId Fastly service id
@@ -19,12 +18,6 @@ module.exports = (apiKey, serviceId) => {
     const vclApi = new Fastly.VclApi();
     const purgeApi = new Fastly.PurgeApi();
 
-    // Settle a promise into the (err, result) callback the callers expect.
-    const toCallback = (promise, cb) => promise.then(
-        result => cb(null, result),
-        err => cb(err)
-    );
-
     // Update first, create on a 404. Mirrors the previous PUT-then-POST upsert.
     const upsert = (update, create) => update().catch(err => {
         if (err && err.status === 404) return create();
@@ -35,82 +28,78 @@ module.exports = (apiKey, serviceId) => {
 
     return {
         // Most recent *active* version for the service (null if none active).
-        getLatestActiveVersion: cb => {
-            if (!serviceId) return cb('Failed to get latest version. No serviceId configured');
-            return toCallback(
-                versionApi.listServiceVersions({service_id: serviceId}).then(versions =>
-                    versions.reduce((latestActiveSoFar, cur) => {
-                        // if one of [latestActiveSoFar, cur] is active and the other isn't,
-                        // return whichever is active. If both are not active, return
-                        // latestActiveSoFar.
-                        if (!cur || !cur.active) return latestActiveSoFar;
-                        if (!latestActiveSoFar || !latestActiveSoFar.active) return cur;
-                        // when both are active, prefer whichever has a higher version number.
-                        return (cur.number > latestActiveSoFar.number) ? cur : latestActiveSoFar;
-                    }, null)
-                ),
-                cb
+        getLatestActiveVersion: () => {
+            if (!serviceId) {
+                return Promise.reject(new Error('Failed to get latest version. No serviceId configured.'));
+            }
+            return versionApi.listServiceVersions({service_id: serviceId}).then(versions =>
+                versions.reduce((latestActiveSoFar, cur) => {
+                    // if one of [latestActiveSoFar, cur] is active and the other isn't,
+                    // return whichever is active. If both are not active, return
+                    // latestActiveSoFar.
+                    if (!cur || !cur.active) return latestActiveSoFar;
+                    if (!latestActiveSoFar || !latestActiveSoFar.active) return cur;
+                    // when both are active, prefer whichever has a higher version number.
+                    return (cur.number > latestActiveSoFar.number) ? cur : latestActiveSoFar;
+                }, null)
             );
         },
 
         // Clone a version to create a new, editable version.
-        cloneVersion: (version, cb) => {
-            if (!serviceId) return cb('Failed to clone version. No serviceId configured.');
-            return toCallback(versionApi.cloneServiceVersion(base(version)), cb);
+        cloneVersion: version => {
+            if (!serviceId) return Promise.reject(new Error('Failed to clone version. No serviceId configured.'));
+            return versionApi.cloneServiceVersion(base(version));
         },
 
         // Activate a version.
-        activateVersion: (version, cb) => {
-            if (!serviceId) return cb('Failed to activate version. No serviceId configured.');
-            return toCallback(versionApi.activateServiceVersion(base(version)), cb);
+        activateVersion: version => {
+            if (!serviceId) return Promise.reject(new Error('Failed to activate version. No serviceId configured.'));
+            return versionApi.activateServiceVersion(base(version));
         },
 
         // Upsert a condition.
-        setCondition: (version, condition, cb) => {
-            if (!serviceId) return cb('Failed to set condition. No serviceId configured');
+        setCondition: (version, condition) => {
+            if (!serviceId) return Promise.reject(new Error('Failed to set condition. No serviceId configured.'));
             const fields = Object.assign(base(version), condition);
-            return toCallback(upsert(
+            return upsert(
                 () => conditionApi.updateCondition(Object.assign({condition_name: condition.name}, fields)),
                 () => conditionApi.createCondition(fields)
-            ), cb);
+            );
         },
 
         // Upsert a header.
-        setFastlyHeader: (version, header, cb) => {
-            if (!serviceId) return cb('Failed to set header. No serviceId configured');
+        setFastlyHeader: (version, header) => {
+            if (!serviceId) return Promise.reject(new Error('Failed to set header. No serviceId configured.'));
             const fields = Object.assign(base(version), header);
-            return toCallback(upsert(
+            return upsert(
                 () => headerApi.updateHeaderObject(Object.assign({header_name: header.name}, fields)),
                 () => headerApi.createHeaderObject(fields)
-            ), cb);
+            );
         },
 
         // Upsert a response object.
-        setResponseObject: (version, responseObject, cb) => {
-            if (!serviceId) return cb('Failed to set response object. No serviceId configured');
+        setResponseObject: (version, responseObject) => {
+            if (!serviceId) return Promise.reject(new Error('Failed to set response object. No serviceId configured.'));
             const fields = Object.assign(base(version), responseObject);
-            return toCallback(upsert(
+            return upsert(
                 () => responseObjectApi.updateResponseObject(
                     Object.assign({response_object_name: responseObject.name}, fields)
                 ),
                 () => responseObjectApi.createResponseObject(fields)
-            ), cb);
+            );
         },
 
         // Upsert a custom VCL include.
-        setCustomVCL: (version, name, vcl, cb) => {
-            if (!serviceId) return cb('Failed to set custom VCL. No serviceId configured');
+        setCustomVCL: (version, name, vcl) => {
+            if (!serviceId) return Promise.reject(new Error('Failed to set custom VCL. No serviceId configured.'));
             const fields = Object.assign(base(version), {name: name, content: vcl});
-            return toCallback(upsert(
+            return upsert(
                 () => vclApi.updateCustomVcl(Object.assign({vcl_name: name}, fields)),
                 () => vclApi.createCustomVcl(fields)
-            ), cb);
+            );
         },
 
         // Purge all content tagged with a surrogate key.
-        purgeKey: (servId, key, cb) => toCallback(
-            purgeApi.purgeTag({service_id: servId, surrogate_key: key}),
-            cb
-        )
+        purgeKey: (servId, key) => purgeApi.purgeTag({service_id: servId, surrogate_key: key})
     };
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,7 +44,6 @@
         "@testing-library/react": "^14.0.0",
         "@testing-library/user-event": "^14.6.1",
         "@types/jest": "29.5.14",
-        "async": "3.2.6",
         "autoprefixer": "10.5.4",
         "babel-loader": "8.4.1",
         "babel-plugin-transform-require-context": "0.1.1",

--- a/package.json
+++ b/package.json
@@ -80,7 +80,6 @@
     "@testing-library/react": "^14.0.0",
     "@testing-library/user-event": "^14.6.1",
     "@types/jest": "29.5.14",
-    "async": "3.2.6",
     "autoprefixer": "10.5.4",
     "babel-loader": "8.4.1",
     "babel-plugin-transform-require-context": "0.1.1",

--- a/test/unit/lib/fastly-extended.test.js
+++ b/test/unit/lib/fastly-extended.test.js
@@ -1,21 +1,22 @@
-describe('fastly library', () => {
+describe('fastly-extended', () => {
     let mockListServiceVersions = jest.fn();
-    // Recorded {api, method, args} for every non-version API call, reset per test.
+    // Recorded {api, method, args} for every non-version-list API call, reset per test.
     let mockCalls = [];
     // When true, every update* call rejects with a 404 so the upsert falls back to create.
     let mockUpdate404 = false;
 
     // A fastly@15 API stub whose every method records its call and returns a promise.
-    // listServiceVersions is routed to mockListServiceVersions so the getLatestActiveVersion
-    // tests can control the version list.
+    // VersionApi.listServiceVersions is routed to mockListServiceVersions so the
+    // getLatestActiveVersion tests can control the version list.
     const mockApi = name => jest.fn(() => new Proxy({}, {
         get: (target, method) => (...args) => {
-            if (name === 'VersionApi' && method === 'listServiceVersions') {
+            const methodName = String(method);
+            if (name === 'VersionApi' && methodName === 'listServiceVersions') {
                 return mockListServiceVersions(...args);
             }
             const callArgs = args[0];
-            mockCalls.push({api: name, method: String(method), args: callArgs});
-            if (String(method).startsWith('update') && mockUpdate404) {
+            mockCalls.push({api: name, method: methodName, args: callArgs});
+            if (methodName.startsWith('update') && mockUpdate404) {
                 const err = new Error('not found');
                 err.status = 404;
                 return Promise.reject(err);
@@ -24,7 +25,6 @@ describe('fastly library', () => {
         }
     }));
 
-    // Mock the fastly@15 client surface that fastly-extended constructs.
     jest.mock('fastly', () => ({
         ApiClient: {instance: {authenticate: jest.fn()}},
         VersionApi: mockApi('VersionApi'),
@@ -39,107 +39,68 @@ describe('fastly library', () => {
     const withVersions = versions => {
         mockListServiceVersions = jest.fn(() => Promise.resolve(versions));
     };
+    const lastCall = () => mockCalls[mockCalls.length - 1];
 
-    test('getLatestActiveVersion returns largest active VCL number, ' +
-        'when called with VCLs in sequential order', done => {
-        withVersions([
-            {number: 1, active: false},
-            {number: 2, active: false},
-            {number: 3, active: true},
-            {number: 4, active: false}
-        ]);
-        const fastlyInstance = fastlyExtended('api_key', 'service_id');
+    beforeEach(() => {
+        mockCalls = [];
+        mockUpdate404 = false;
+    });
 
-        fastlyInstance.getLatestActiveVersion((err, response) => {
-            expect(err).toBe(null);
-            expect(response).toEqual({number: 3, active: true});
+    describe('getLatestActiveVersion', () => {
+        test('returns the largest active version, sequential order', async () => {
+            withVersions([
+                {number: 1, active: false},
+                {number: 2, active: false},
+                {number: 3, active: true},
+                {number: 4, active: false}
+            ]);
+            const fastly = fastlyExtended('api_key', 'service_id');
+            expect(await fastly.getLatestActiveVersion()).toEqual({number: 3, active: true});
             expect(mockListServiceVersions).toHaveBeenCalledWith({service_id: 'service_id'});
-            done();
+        });
+
+        test('returns the largest active version, mixed order', async () => {
+            withVersions([
+                {number: 4, active: false},
+                {number: 1, active: false},
+                {number: 2, active: true},
+                {number: 3, active: false}
+            ]);
+            const fastly = fastlyExtended('api_key', 'service_id');
+            expect(await fastly.getLatestActiveVersion()).toEqual({number: 2, active: true});
+        });
+
+        test('returns null when no version is active', async () => {
+            withVersions([
+                {number: 1, active: false},
+                {number: 2, active: false}
+            ]);
+            const fastly = fastlyExtended('api_key', 'service_id');
+            expect(await fastly.getLatestActiveVersion()).toEqual(null);
+        });
+
+        test('returns the single active version', async () => {
+            withVersions([{number: 1, active: true}]);
+            const fastly = fastlyExtended('api_key', 'service_id');
+            expect(await fastly.getLatestActiveVersion()).toEqual({number: 1, active: true});
+        });
+
+        test('rejects when no serviceId is configured', async () => {
+            const fastly = fastlyExtended('api_key', '');
+            await expect(fastly.getLatestActiveVersion()).rejects.toThrow(/No serviceId/);
         });
     });
 
-    test('getLatestActiveVersion returns largest active VCL number, when called with VCLs in mixed up order', done => {
-        withVersions([
-            {number: 4, active: false},
-            {number: 1, active: false},
-            {number: 2, active: true},
-            {number: 3, active: false}
-        ]);
-        const fastlyInstance = fastlyExtended('api_key', 'service_id');
-
-        fastlyInstance.getLatestActiveVersion((err, response) => {
-            expect(err).toBe(null);
-            expect(response).toEqual({number: 2, active: true});
-            expect(mockListServiceVersions).toHaveBeenCalledWith({service_id: 'service_id'});
-            done();
-        });
-    });
-
-    test('getLatestActiveVersion returns null, when none of the VCL versions are active', done => {
-        withVersions([
-            {number: 4, active: false},
-            {number: 1, active: false},
-            {number: 2, active: false},
-            {number: 3, active: false}
-        ]);
-        const fastlyInstance = fastlyExtended('api_key', 'service_id');
-
-        fastlyInstance.getLatestActiveVersion((err, response) => {
-            expect(err).toBe(null);
-            expect(response).toEqual(null);
-            expect(mockListServiceVersions).toHaveBeenCalledWith({service_id: 'service_id'});
-            done();
-        });
-    });
-
-    test('getLatestActiveVersion returns largest active VCL number, ' +
-        'when called with a single active VCL', done => {
-        withVersions([
-            {number: 1, active: true}
-        ]);
-        const fastlyInstance = fastlyExtended('api_key', 'service_id');
-
-        fastlyInstance.getLatestActiveVersion((err, response) => {
-            expect(err).toBe(null);
-            expect(response).toEqual({number: 1, active: true});
-            expect(mockListServiceVersions).toHaveBeenCalledWith({service_id: 'service_id'});
-            done();
-        });
-    });
-
-    test('getLatestActiveVersion returns null, when called with a single inactive VCL', done => {
-        withVersions([
-            {number: 1, active: false}
-        ]);
-        const fastlyInstance = fastlyExtended('api_key', 'service_id');
-
-        fastlyInstance.getLatestActiveVersion((err, response) => {
-            expect(err).toBe(null);
-            expect(response).toEqual(null);
-            expect(mockListServiceVersions).toHaveBeenCalledWith({service_id: 'service_id'});
-            done();
-        });
-    });
-
-    describe('wrapper wiring to the fastly@15 API', () => {
-        const fastlyInstance = fastlyExtended('api_key', 'service_id');
-        // Bridge the wrapper's (err, result) callbacks into a promise for async tests.
-        const call = fn => new Promise((resolve, reject) => {
-            fn((err, result) => (err ? reject(err) : resolve(result)));
-        });
-        const lastCall = () => mockCalls[mockCalls.length - 1];
-
-        beforeEach(() => {
-            mockCalls = [];
-            mockUpdate404 = false;
-        });
+    describe('upserts and versions', () => {
+        const fastly = fastlyExtended('api_key', 'service_id');
 
         test('setCondition updates an existing condition with the merged params', async () => {
-            await call(cb => fastlyInstance.setCondition(7, {
+            await fastly.setCondition(7, {
                 name: 'routes/x (request)', statement: 'req.url ~ "x"', type: 'REQUEST', priority: 11
-            }, cb));
+            });
             expect(mockCalls).toHaveLength(1);
-            expect(lastCall()).toEqual({api: 'ConditionApi',
+            expect(lastCall()).toEqual({
+                api: 'ConditionApi',
                 method: 'updateCondition',
                 args: {
                     service_id: 'service_id',
@@ -149,14 +110,13 @@ describe('fastly library', () => {
                     statement: 'req.url ~ "x"',
                     type: 'REQUEST',
                     priority: 11
-                }});
+                }
+            });
         });
 
         test('setCondition falls back to createCondition on a 404', async () => {
             mockUpdate404 = true;
-            await call(cb => fastlyInstance.setCondition(7, {
-                name: 'c', statement: 's', type: 'REQUEST', priority: 1
-            }, cb));
+            await fastly.setCondition(7, {name: 'c', statement: 's', type: 'REQUEST', priority: 1});
             expect(mockCalls.map(c => `${c.api}.${c.method}`)).toEqual(
                 ['ConditionApi.updateCondition', 'ConditionApi.createCondition']
             );
@@ -168,61 +128,45 @@ describe('fastly library', () => {
 
         test('setFastlyHeader uses header_name to update and omits it when creating', async () => {
             mockUpdate404 = true;
-            await call(cb => fastlyInstance.setFastlyHeader(7, {
-                name: 'rewrites/a',
-                action: 'set',
-                ignore_if_set: 0,
-                type: 'REQUEST',
-                dst: 'url',
-                src: '"/a.html"',
-                request_condition: 'rc',
-                priority: 10
-            }, cb));
+            await fastly.setFastlyHeader(7, {
+                name: 'rewrites/a', action: 'set', type: 'REQUEST', dst: 'url', src: '"/a.html"'
+            });
             expect(mockCalls[0].method).toBe('updateHeaderObject');
             expect(mockCalls[0].args.header_name).toBe('rewrites/a');
             expect(mockCalls[1].method).toBe('createHeaderObject');
-            expect(mockCalls[1].args.dst).toBe('url');
             expect(mockCalls[1].args.header_name).toBeUndefined();
         });
 
         test('setResponseObject updates with response_object_name', async () => {
-            await call(cb => fastlyInstance.setResponseObject(7, {
-                name: 'redirects/a', status: 301, response: 'Moved Permanently', request_condition: 'rc'
-            }, cb));
+            await fastly.setResponseObject(7, {name: 'redirects/a', status: 301, response: 'Moved Permanently'});
             expect(lastCall().method).toBe('updateResponseObject');
             expect(lastCall().args.response_object_name).toBe('redirects/a');
             expect(lastCall().args.status).toBe(301);
         });
 
         test('setCustomVCL updates with vcl_name and content', async () => {
-            await call(cb => fastlyInstance.setCustomVCL(7, 'recv-condition', 'if (true) {}', cb));
+            await fastly.setCustomVCL(7, 'recv-condition', 'if (true) {}');
             expect(lastCall().method).toBe('updateCustomVcl');
             expect(lastCall().args.vcl_name).toBe('recv-condition');
             expect(lastCall().args.content).toBe('if (true) {}');
         });
 
-        test('purgeKey calls purgeTag with the surrogate key', async () => {
-            await call(cb => fastlyInstance.purgeKey('service_id', 'static-assets', cb));
-            expect(lastCall()).toEqual({api: 'PurgeApi',
-                method: 'purgeTag',
-                args: {
-                    service_id: 'service_id', surrogate_key: 'static-assets'
-                }});
+        test('cloneVersion and activateVersion hit the version API', async () => {
+            await fastly.cloneVersion(7);
+            expect(lastCall()).toEqual({
+                api: 'VersionApi', method: 'cloneServiceVersion', args: {service_id: 'service_id', version_id: 7}
+            });
+            await fastly.activateVersion(7);
+            expect(lastCall()).toEqual({
+                api: 'VersionApi', method: 'activateServiceVersion', args: {service_id: 'service_id', version_id: 7}
+            });
         });
 
-        test('cloneVersion and activateVersion hit the version API', async () => {
-            await call(cb => fastlyInstance.cloneVersion(7, cb));
-            expect(lastCall()).toEqual({api: 'VersionApi',
-                method: 'cloneServiceVersion',
-                args: {
-                    service_id: 'service_id', version_id: 7
-                }});
-            await call(cb => fastlyInstance.activateVersion(7, cb));
-            expect(lastCall()).toEqual({api: 'VersionApi',
-                method: 'activateServiceVersion',
-                args: {
-                    service_id: 'service_id', version_id: 7
-                }});
+        test('purgeKey calls purgeTag with the surrogate key', async () => {
+            await fastly.purgeKey('service_id', 'static-assets');
+            expect(lastCall()).toEqual({
+                api: 'PurgeApi', method: 'purgeTag', args: {service_id: 'service_id', surrogate_key: 'static-assets'}
+            });
         });
     });
 });


### PR DESCRIPTION
### Resolves:

No single tracking issue. This is a step of the Fastly config refactor, after
the two prep PRs scratchfoundation/scratch-www#10354 (routes.json -> routes.js)
and scratchfoundation/scratch-www#10355 (fastly@15 client). It splits the
refactor's "how the code is written" change away from the upcoming "what we send
to Fastly" change so each can be reviewed on its own.

### Changes:

Make the Fastly config promise-native, with no change to what is configured on
the service:

- `bin/lib/fastly-extended.js`: drop the callback surface (and the `toCallback`
  bridge #10355 left as scaffolding); every method now returns a Promise.
- `bin/configure-fastly.js`: rewritten from `async.auto` to `async`/`await` +
  `Promise.all`, preserving the exact per-route mechanism -- same conditions,
  headers, response objects, custom VCL, priorities, and activation/purge.
- Remove the now-unused `async` dependency.

The follow-up PR (stacked on this one) swaps that per-route mechanism for
generated VCL snippets; keeping it separate means that PR's diff is purely the
mechanism change, not promise-conversion noise.

### Test Coverage:

- `test/unit/lib/fastly-extended.test.js` updated to the promise surface:
  `getLatestActiveVersion` (5 orderings incl. none-active and no-serviceId),
  the `setCondition` / `setFastlyHeader` / `setResponseObject` / `setCustomVCL`
  upserts (update-then-create-on-404, correct `*_name` path params), and
  clone/activate/purge.
- `test/unit-legacy/test_fastly_config_methods.js` still passes; eslint clean.
- Behavior is verified against staging by a `configure-fastly` dry run (with
  `FASTLY_ACTIVATE_CHANGES` unset) confirming the same objects are written, before
  it reaches production via master.
